### PR TITLE
Draft: Very initial Library implementation

### DIFF
--- a/framework/Common.cpp
+++ b/framework/Common.cpp
@@ -3003,6 +3003,8 @@ void idCommonLocal::InitGame( void )
 	// tels: #3199: now that the game DLL is loaded, we can execute another config, this
 	// enables it to run f.i. dmap (dmap before DLL load produces no AAS):
 	cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "exec autocommands.cfg\n" );
+
+	gameLocal.LoadLibraries();
 }
 
 /*

--- a/game/Game_local.cpp
+++ b/game/Game_local.cpp
@@ -358,6 +358,7 @@ void idGameLocal::Clear( void )
 	spawnCount = INITIAL_SPAWN_COUNT;
 	mapSpawnCount = 0;
 	camera = NULL;
+	library = NULL;
 	aasList.Clear();
 	aasNames.Clear();
 	spawnArgs.Clear();
@@ -8364,6 +8365,16 @@ int idGameLocal::LogSuspiciousEvent( SuspiciousEvent se, bool forceLog ) // gray
 	}
 
 	return index;
+}
+
+Library* idGameLocal::GetLibrary()
+{
+    // Only set up a library if we know that we can use it.
+    if (!library) {
+	library = new Library();
+    }
+
+    return library;
 }
 
 

--- a/game/Game_local.cpp
+++ b/game/Game_local.cpp
@@ -8369,12 +8369,23 @@ int idGameLocal::LogSuspiciousEvent( SuspiciousEvent se, bool forceLog ) // gray
 
 Library* idGameLocal::GetLibrary()
 {
-    // Only set up a library if we know that we can use it.
-    if (!library) {
-	library = new Library();
-    }
+	// Only set up a library if we know that we need it.
+	if (!library) {
+		library = new Library(true);
+		library->Construct("(manager)", true);
+	}
 
-    return library;
+	return library;
+}
+
+void idGameLocal::LoadLibraries()
+{
+	if (!library) {
+		Printf( "Libraries: (not used)\n" );
+		return;
+	}
+
+	library->LoadAll();
 }
 
 

--- a/game/Game_local.h
+++ b/game/Game_local.h
@@ -112,6 +112,7 @@ void gameError( const char *fmt, ... );
 #include "LightController.h"
 #include "ModMenu.h"
 #include "LodComponent.h"
+#include "script/Library.h"
 
 //============================================================================
 
@@ -991,6 +992,8 @@ public:
 	int						FindSuspiciousEvent( EventType type, idVec3 location, idEntity* entity, int time ); // grayman #3424
 	SuspiciousEvent*		FindSuspiciousEvent( int eventID ); // grayman #3857
 	int						LogSuspiciousEvent( SuspiciousEvent se, bool forceLog ); // grayman #3424 grayman #3857
+
+	Library*				GetLibrary();
 	
 private:
 	const static int		INITIAL_SPAWN_COUNT = 1;
@@ -1058,6 +1061,8 @@ private:
 	idList<idStr>				m_GUICommandStack;
 	// how many arguments do we expect for the current command (m_GUICommandStack[0]):
 	int							m_GUICommandArgs;
+
+	Library*				library;
 
 	void					Clear( void );
 

--- a/game/Game_local.h
+++ b/game/Game_local.h
@@ -994,6 +994,7 @@ public:
 	int						LogSuspiciousEvent( SuspiciousEvent se, bool forceLog ); // grayman #3424 grayman #3857
 
 	Library*				GetLibrary();
+	void					LoadLibraries();
 	
 private:
 	const static int		INITIAL_SPAWN_COUNT = 1;

--- a/game/gamesys/EventArgs.h
+++ b/game/gamesys/EventArgs.h
@@ -82,6 +82,8 @@ public:
 			  char argType6, const char* argName6, const char* argDesc6,
 			  char argType7, const char* argName7, const char* argDesc7,
 			  char argType8, const char* argName8, const char* argDesc8);
+
+	inline EventArgs(idList<EventArg>* argList);
 };
 
 inline int EventArgs::size() const {
@@ -203,4 +205,16 @@ inline EventArgs::EventArgs(char argType1, const char* argName1, const char* arg
 	args[7].type = argType8; args[7].name = argName8; args[7].desc = argDesc8;
 }
 
+inline EventArgs::EventArgs(idList<EventArg>* argList) {
+	int i;
+
+	// EventArgs are capped at length 8.
+	assert((*argList).Num() <= 8);
+
+	for ( i = 0; i < (*argList).Num(); i++ ) {
+		args[i].type = (*argList)[i].type;
+		args[i].name = (*argList)[i].name;
+		args[i].desc = (*argList)[i].desc;
+	}
+}
 #endif

--- a/game/gamesys/TypeInfo_GenHelper.h
+++ b/game/gamesys/TypeInfo_GenHelper.h
@@ -66,6 +66,7 @@ Project: The Dark Mod (http://www.thedarkmod.com/)
 #include "../game/PVSToAASMapping.h"
 #include "../game/RawVector.h"
 #include "../game/Relations.h"
+#include "../game/script/Library.h"
 #include "../game/script/Script_Compiler.h"
 #include "../game/script/Script_Doc_Export.h"
 #include "../game/script/Script_Interpreter.h"

--- a/game/script/Library.cpp
+++ b/game/script/Library.cpp
@@ -1,0 +1,123 @@
+/*****************************************************************************
+The Dark Mod GPL Source Code
+
+This file is part of the The Dark Mod Source Code, originally based
+on the Doom 3 GPL Source Code as published in 2011.
+
+The Dark Mod Source Code is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version. For details, see LICENSE.TXT.
+
+Project: The Dark Mod (http://www.thedarkmod.com/)
+
+******************************************************************************/
+
+#include "../Game_local.h"
+#include "../DarkModGlobals.h"
+#include "Library.h"
+
+//===============================================================================
+// Library
+//===============================================================================
+
+idTypeInfo Library::Type( "Library", "idClass",
+	( idEventFunc<idClass> * )Library::eventCallbacks,	Library::CreateInstance, ( void ( idClass::* )( void ) )&Library::Spawn,
+	( void ( idClass::* )( idSaveGame * ) const )&Library::Save, ( void ( idClass::* )( idRestoreGame * ) )&Library::Restore );
+idList<Library*> Library::libraries;
+idHashIndex Library::libraryHash;
+
+idClass *Library::CreateInstance( void ) {
+	try {
+		Library *ptr = new Library;
+		/*ptr->FindUninitializedMemory();*/
+		return ptr;
+	}
+	catch( idAllocError & ) {
+		return NULL;
+	}
+}
+
+idTypeInfo *Library::GetType( void ) const {
+	return &( Library::Type );
+}
+
+const idEventDef EV_TDM_Library_GetLibraryCount( "GetLibraryCount", EventArgs(), 'f', "Returns the number of loaded pre-compiled mod libraries." );
+
+/*
+================
+Library::Library
+================
+*/
+Library::Library()
+{
+	DM_LOG(LC_FUNCTION, LT_DEBUG)LOGSTRING("library: %08lX %s\r", this, __FUNCTION__);
+
+	libraryNumber	= -1;
+}
+
+int Library::GetLibraryCount() {
+	return libraries.Num();
+}
+
+void Library::Event_GetLibraryCount() {
+	idThread::ReturnInt(GetLibraryCount());
+}
+
+
+idEventFunc<Library> Library::eventCallbacks[] = {
+	EVENT( EV_TDM_Library_GetLibraryCount,					Library::Event_GetLibraryCount )
+};
+
+/*
+=============
+Library::FindLibrary
+
+Returns the entity whose name matches the specified string.
+=============
+*/
+Library *Library::FindLibrary( const char *name ) {
+	int hash, i;
+
+	hash = libraryHash.GenerateKey( name, true );
+	for ( i = libraryHash.First( hash ); i != -1; i = libraryHash.Next( i ) ) {
+		if ( libraries[i] && libraries[i]->name.Icmp( name ) == 0 ) {
+			return libraries[i];
+		}
+	}
+
+	return NULL;
+}
+
+/*
+================
+Library::AddLibraryToHash
+================
+*/
+bool Library::AddLibraryToHash( const char *name, Library *library ) {
+	if ( FindLibrary( name ) ) {
+		printf( "Multiple libraries named '%s'", name );
+		return false;
+	}
+	libraryHash.Add( libraryHash.GenerateKey( name, true ), library->libraryNumber );
+	return true;
+}
+
+/*
+================
+Library::RemoveLibraryFromHash
+================
+*/
+bool Library::RemoveLibraryFromHash( const char *name, Library *library ) {
+	int hash, i;
+
+	hash = libraryHash.GenerateKey( name, true );
+	for ( i = libraryHash.First( hash ); i != -1; i = libraryHash.Next( i ) ) {
+		if ( libraries[i] && libraries[i] == library && libraries[i]->name.Icmp( name ) == 0 ) {
+			libraryHash.Remove( hash, i );
+			return true;
+		}
+	}
+	return false;
+}
+;

--- a/game/script/Library.cpp
+++ b/game/script/Library.cpp
@@ -16,20 +16,20 @@ Project: The Dark Mod (http://www.thedarkmod.com/)
 #include "../Game_local.h"
 #include "../DarkModGlobals.h"
 #include "Library.h"
+#include <dlfcn.h>
 
 //===============================================================================
 // Library
 //===============================================================================
 
-idTypeInfo Library::Type( "Library", "idClass",
-	( idEventFunc<idClass> * )Library::eventCallbacks,	Library::CreateInstance, ( void ( idClass::* )( void ) )&Library::Spawn,
-	( void ( idClass::* )( idSaveGame * ) const )&Library::Save, ( void ( idClass::* )( idRestoreGame * ) )&Library::Restore );
 idList<Library*> Library::libraries;
 idHashIndex Library::libraryHash;
 
+typedef void (*idClassCallback)( void );
+
 idClass *Library::CreateInstance( void ) {
 	try {
-		Library *ptr = new Library;
+		Library *ptr = new Library();
 		/*ptr->FindUninitializedMemory();*/
 		return ptr;
 	}
@@ -39,7 +39,7 @@ idClass *Library::CreateInstance( void ) {
 }
 
 idTypeInfo *Library::GetType( void ) const {
-	return &( Library::Type );
+	return Type;
 }
 
 const idEventDef EV_TDM_Library_GetLibraryCount( "GetLibraryCount", EventArgs(), 'f', "Returns the number of loaded pre-compiled mod libraries." );
@@ -49,11 +49,46 @@ const idEventDef EV_TDM_Library_GetLibraryCount( "GetLibraryCount", EventArgs(),
 Library::Library
 ================
 */
-Library::Library()
+Library::Library(bool mgr) : name(""), path(""), mgr(mgr), shdHandle(0), Type(NULL), libraryModule(NULL) {
+	if (mgr) {
+		Type = new idTypeInfo(
+			"Library", "idClass",
+			( idEventFunc<idClass> * )Library::eventCallbacks,
+			Library::CreateInstance,
+			( void ( idClass::* )( void ) )&Library::Spawn,
+			( void ( idClass::* )( idSaveGame * ) const )&Library::Save,
+			( void ( idClass::* )( idRestoreGame * ) )&Library::Restore
+		);
+	}
+	functions.SetGranularity( 1 );
+}
+
+Library::~Library() {
+	if (shdHandle) {
+		Sys_DLL_Unload( shdHandle );
+	}
+}
+
+void Library::Construct(idStr _name, bool _mgr)
 {
 	DM_LOG(LC_FUNCTION, LT_DEBUG)LOGSTRING("library: %08lX %s\r", this, __FUNCTION__);
 
-	libraryNumber	= -1;
+	name = _name;
+	assert(mgr == _mgr);
+	if (_mgr) {
+		assert(name == "(manager)");
+		libraryNumber	= -1;
+	} else {
+		libraryNumber	= GetLibraryCount();
+		libraries.Append(this);
+		AddLibraryToHash(name, this);
+		gameLocal.program.SetLibrary(name, this);
+	}
+}
+
+const function_t* Library::GetLibraryFunction(int libraryNumber, int functionNumber) {
+	// TODO: errors
+	return libraries[libraryNumber]->GetFunction(functionNumber);
 }
 
 int Library::GetLibraryCount() {
@@ -89,6 +124,30 @@ Library *Library::FindLibrary( const char *name ) {
 	return NULL;
 }
 
+Library* Library::AddLibrary(const char *name) {
+	Library *library = FindLibrary(name);
+	if (!library) {
+		library = (Library*)Library::CreateInstance();
+		library->Construct(name, false);
+	}
+	return library;
+}
+
+void Library::DebugInfo() {
+	if (mgr) {
+		int count = GetLibraryCount();
+		gameLocal.Printf("Libraries: [MGR] there are %d libraries loaded\n", count);
+		if (count) {
+			for ( Library** li = libraries.begin(); li != libraries.end(); ++li ) {
+				(*li)->DebugInfo();
+			}
+		}
+	} else {
+		int count = functions.Num();
+		gameLocal.Printf("Libraries: [%s] has %d functions\n", name.c_str(), count);
+	}
+}
+
 /*
 ================
 Library::AddLibraryToHash
@@ -120,4 +179,216 @@ bool Library::RemoveLibraryFromHash( const char *name, Library *library ) {
 	}
 	return false;
 }
-;
+
+/*
+================
+Library::NumFunctions
+================
+*/
+int Library::NumFunctions( void ) const {
+	return functions.Num();
+}
+
+/*
+================
+Library::GetFunctionNumber
+================
+*/
+int Library::GetFunctionNumber( const function_t *func ) const {
+	int i;
+
+	for( i = 0; i < functions.Num(); i++ ) {
+		if ( functions[ i ] == func ) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+/*
+================
+Library::GetFunction
+================
+*/
+const function_t *Library::GetFunction( int funcNumber ) const {
+	assert( funcNumber >= 0 );
+	assert( funcNumber < functions.Num() );
+	return functions[ funcNumber ];
+}
+
+/*
+============
+Library::Error
+
+Aborts the currently executing function
+============
+*/
+void Library::Error( const char *fmt, ... ) const {
+	va_list argptr;
+	char	text[ 1024 ];
+
+	va_start( argptr, fmt );
+	vsprintf( text, fmt, argptr );
+	va_end( argptr );
+
+	common->Error( "Library '%s': %s\n", name.c_str(), text );
+}
+
+/*
+================
+Library::AddFunction
+================
+*/
+void Library::AddFunction( const function_t *func ) {
+	int i;
+
+	for( i = 0; i < functions.Num(); i++ ) {
+		if ( !strcmp( functions[ i ]->def->Name(), func->def->Name() ) ) {
+			if ( func->def->TypeDef()->MatchesVirtualFunction( *functions[ i ]->def->TypeDef() ) ) {
+				// Keep the original, so we do not overwrite a loaded function
+				// We let this get to here to make sure that we do not have an incompatible alternative
+				// definition.
+				return;
+			} else {
+				Error("Tried to add two different functions called '%s' in library '%s'", func->def->Name(), name.c_str());
+			}
+		}
+	}
+	functions.Append( func );
+}
+
+void Library::LoadAll() {
+	for ( Library* library : libraries ) {
+		library->Load();
+	}
+}
+
+typedef union {
+	eventCallback_t cb;
+	struct {
+		uintptr_t ptr;
+		ptrdiff_t adj;
+	};
+} ptmf_t;
+
+typedef void (*myfunc)();
+
+void Library::Load() {
+	idFile *fp;
+
+	if (path == "") {
+		Error("No library definition script was ever loaded for this library");
+	}
+
+	for ( const function_t* func : functions ) {
+		if ( func->def->initialized == idVarDef::uninitialized ) {
+			Error("Function '%s' was found in a calling module but no definition was ever loaded", func->Name());
+		} else if ( func->def->initialized != idVarDef::stackVariable ) {
+			Error("Function '%s' was loaded but is in the wrong state - perhaps it was loaded already?", func->Name());
+		}
+	}
+
+	libraryModule = new LibraryModule(this, path, "test");
+	libraryModule->Load(functions, &functionCallbacks);
+
+	Type = new idTypeInfo(
+		name.c_str(), "idClass", // Not inheriting from Library as we do not inherit the events.
+		functionCallbacks.Ptr(),
+		Library::CreateInstance,
+		( void ( idClass::* )( void ) )&Library::Spawn,
+		( void ( idClass::* )( idSaveGame * ) const )&Library::Save,
+		( void ( idClass::* )( idRestoreGame * ) )&Library::Restore
+	);
+	Type->Init();
+}
+
+#include <iostream>
+#include <dlfcn.h>
+
+template <typename T>
+void LibraryModule::LoadFunction(T* funcPtr, const char* name) {
+	idStr fnName = name;
+	uintptr_t fnHandle = reinterpret_cast<uintptr_t>(Sys_DLL_GetProcAddress( fh, fnName ));
+
+	if ( !fnHandle ) {
+		Sys_DLL_Unload( fh );
+		fh = 0;
+		Error( "couldn't find library DLL function: '%s' in DLL '%s'", fnName.c_str(), dllName.c_str() );
+	}
+	*funcPtr = *(reinterpret_cast<T*>(&fnHandle));
+}
+
+/*
+============
+LibraryModule::Error
+
+Aborts the currently executing function
+============
+*/
+void LibraryModule::Error( const char *fmt, ... ) const {
+	va_list argptr;
+	char	text[ 1024 ];
+
+	va_start( argptr, fmt );
+	vsprintf( text, fmt, argptr );
+	va_end( argptr );
+
+	common->Error( "Library Module '%s': %s\n", dllName.c_str(), text );
+}
+
+void LibraryModule::Load(idList<const function_t*> requestedFunctions, idList<idEventFunc<idClass>>* functionCallbacks) {
+	char dllPath[ MAX_OSPATH ];
+
+	strcpy(dllPath, path.StripFilename().c_str());
+	idLib::fileSystem->FindDLL( dllName, dllPath, true );
+
+	if ( !dllPath[0] ) {
+		Error( "couldn't find game dynamic library from '%s/%s'", dllPath, path.StripPath().c_str() );
+		return;
+	}
+
+	fh = idLib::sys->DLL_Load( dllPath );
+	if ( !fh ) {
+		Error( "couldn't load game dynamic library from '%s'", dllPath );
+		return;
+	}
+
+	int i = 0;
+	functionCallbacks->Resize(requestedFunctions.Num() + 1);
+
+	LoadFunction(&Initialize, "trm__initialize");
+	LoadFunction(&Deinitialize, "trm__deinitialize");
+	LoadFunction(&GetModuleName, "trm__module_name");
+	const char* moduleName = (parentLibrary->*GetModuleName)();
+
+	char functionName[2000] = "";
+	for ( const function_t** func = requestedFunctions.begin() ; func != requestedFunctions.end() ; func++ ) {
+		// This is a hacky workaround for the fact we do not want to pass `this` to
+		// a library function. Nicer would require changing Class.cpp to use generic functions.
+		idStr fnName = (*func)->Name();
+		fnName = fnName.Split({ ":" }, true).Last();
+		sprintf(functionName, "trm__usermod__%s__%s", moduleName, fnName.c_str());
+		eventCallback_t functionHandle;
+		LoadFunction(&functionHandle, functionName);
+//
+		(*functionCallbacks)[i] = idEventFunc<idClass> {
+			(*func)->eventdef,
+			functionHandle
+		};
+		i++;
+	}
+
+	(*functionCallbacks)[requestedFunctions.Num()] = {NULL, NULL};
+
+	(parentLibrary->*Initialize)();
+}
+
+LibraryModule::~LibraryModule() {
+	if (fh != 0) {
+		if (Deinitialize) {
+			(parentLibrary->*Deinitialize)();
+		}
+		Sys_DLL_Unload( fh );
+		fh = 0;
+	}
+}

--- a/game/script/Library.h
+++ b/game/script/Library.h
@@ -1,0 +1,48 @@
+/*****************************************************************************
+The Dark Mod GPL Source Code
+
+This file is part of the The Dark Mod Source Code, originally based
+on the Doom 3 GPL Source Code as published in 2011.
+
+The Dark Mod Source Code is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version. For details, see LICENSE.TXT.
+
+Project: The Dark Mod (http://www.thedarkmod.com/)
+
+******************************************************************************/
+
+#ifndef _LIBRARY_H
+#define _LIBRARY_H
+
+#include "../gamesys/Class.h"
+
+class Library : public idClass
+{
+public:
+	int GetLibraryCount();
+	static	idTypeInfo						Type;
+	static	idClass							*CreateInstance( void );
+	virtual	idTypeInfo						*GetType( void ) const override;
+	static	idEventFunc<Library>		eventCallbacks[];
+	int								libraryNumber;
+	idStr								name;
+	static	idHashIndex						libraryHash;				// hash table to quickly find entities by name
+	static	Library*						FindLibrary( const char *name );
+	static	bool							AddLibraryToHash( const char *name, Library *library );
+	static	bool							RemoveLibraryFromHash( const char *name, Library *library );
+	static	idList<Library *>					libraries;	// index to entities
+
+	Library();
+
+	ID_INLINE void Spawn() {}
+	ID_INLINE void Save(idSaveGame *savefile) {}
+	ID_INLINE void Restore( idRestoreGame *savefile ) {}
+
+protected:
+	void Event_GetLibraryCount();
+
+};
+
+#endif /* _LIBRARY_H */

--- a/game/script/Library.h
+++ b/game/script/Library.h
@@ -18,30 +18,73 @@ Project: The Dark Mod (http://www.thedarkmod.com/)
 
 #include "../gamesys/Class.h"
 
+typedef bool (idClass::*boolFunc) ();
+typedef const char* (idClass::*strFunc) ();
+class Library;
+
+class LibraryModule {
+	public:
+		LibraryModule(Library* library, idStr _path, idStr _dllName) : parentLibrary(library), path(_path), dllName(_dllName), fh(0) {}
+		~LibraryModule();
+		void Load(idList<const function_t*> requestedFunctions, idList<idEventFunc<idClass>>* functionCallbacks);
+
+	private:
+		Library *parentLibrary;
+		idStr path;
+		idStr dllName;
+		uintptr_t fh;
+		boolFunc Initialize;
+		strFunc GetModuleName;
+		boolFunc Deinitialize;
+		template <typename T>
+		void LoadFunction(T* funcPtr, const char* name);
+		void Error( const char *fmt, ... ) const id_attribute((format(printf,2,3)));
+};
+
 class Library : public idClass
 {
 public:
 	int GetLibraryCount();
-	static	idTypeInfo						Type;
+	idTypeInfo							*Type;
 	static	idClass							*CreateInstance( void );
 	virtual	idTypeInfo						*GetType( void ) const override;
-	static	idEventFunc<Library>		eventCallbacks[];
+	static idEventFunc<Library>					eventCallbacks[];
+	void								LoadAll( void );
+	void								Load( void );
 	int								libraryNumber;
+	idStr								path;
 	idStr								name;
+	Library*							AddLibrary( const char *name );
+	void								DebugInfo();
+	bool								mgr;
+	const function_t						*GetLibraryFunction(int libraryNumber, int functionNumber);
+	int					NumFunctions( void ) const;
+	int					GetFunctionNumber( const function_t *func ) const;
+	const function_t	*GetFunction( int funcNumber ) const;
+	void				AddFunction( const function_t *func );
+	void				Error( const char *fmt, ... ) const id_attribute((format(printf,2,3)));
+	idList<const function_t *>					functions;
 	static	idHashIndex						libraryHash;				// hash table to quickly find entities by name
 	static	Library*						FindLibrary( const char *name );
 	static	bool							AddLibraryToHash( const char *name, Library *library );
 	static	bool							RemoveLibraryFromHash( const char *name, Library *library );
 	static	idList<Library *>					libraries;	// index to entities
 
-	Library();
+	Library(bool mgr = false);
+	~Library();
+	void Construct(idStr name, bool mgr = false);
 
 	ID_INLINE void Spawn() {}
 	ID_INLINE void Save(idSaveGame *savefile) {}
 	ID_INLINE void Restore( idRestoreGame *savefile ) {}
 
+private:
+	uintptr_t shdHandle;
+	LibraryModule* libraryModule;
+
 protected:
 	void Event_GetLibraryCount();
+	idList<idEventFunc<idClass>>					functionCallbacks;
 
 };
 

--- a/game/script/Script_Compiler.h
+++ b/game/script/Script_Compiler.h
@@ -205,6 +205,7 @@ private:
 	int				currentLineNumber;
 	int				currentFileNumber;
 	int				errorCount;
+	Library*			activeLibrary;
 					
 	idVarDef		*scope;				// the function being parsed, or NULL
 	const idVarDef	*basetype;			// for accessing fields
@@ -253,8 +254,9 @@ private:
 	void			ParseStatement( void );
 	void			ParseObjectDef( const char *objname );
 	idTypeDef		*ParseFunction( idTypeDef *returnType, const char *name );
+	idTypeDef		*ParseLibraryFunction( idTypeDef *returnType, const char *name );
 	void			ParseFunctionDef( idTypeDef *returnType, const char *name );
-	void			ParseExternDef( idTypeDef *returnType, const char *name );
+	void			ParseLibraryFunctionDef( idTypeDef *returnType, const char *name );
 	void			ParseVariableDef( idTypeDef *type, const char *name );
 	void			ParseEventDef( idTypeDef *type, const char *name );
 	void			ParseDefs( void );

--- a/game/script/Script_Compiler.h
+++ b/game/script/Script_Compiler.h
@@ -92,6 +92,7 @@ enum {
 	OP_EVENTCALL,
 	OP_OBJECTCALL,
 	OP_SYSCALL,
+	OP_LIBCALL, // TDM libraries
 
 	OP_STORE_F,
 	OP_STORE_V,
@@ -237,6 +238,7 @@ private:
 	idVarDef		*ParseObjectCall( idVarDef *object, idVarDef *func );
 	idVarDef		*ParseEventCall( idVarDef *object, idVarDef *func );
 	idVarDef		*ParseSysObjectCall( idVarDef *func );
+	idVarDef		*ParseLibCall( idVarDef *libDef, idVarDef *func );
 	idVarDef		*LookupDef( const char *name, const idVarDef *baseobj );
 	idVarDef		*ParseValue( void );
 	idVarDef		*GetTerm( void );
@@ -252,6 +254,7 @@ private:
 	void			ParseObjectDef( const char *objname );
 	idTypeDef		*ParseFunction( idTypeDef *returnType, const char *name );
 	void			ParseFunctionDef( idTypeDef *returnType, const char *name );
+	void			ParseExternDef( idTypeDef *returnType, const char *name );
 	void			ParseVariableDef( idTypeDef *type, const char *name );
 	void			ParseEventDef( idTypeDef *type, const char *name );
 	void			ParseDefs( void );
@@ -264,6 +267,7 @@ public :
 	void			CompileFile( const char *text, const char *filename, bool console );
 
 	static idTypeDef		*GetTypeForEventArg( char argType );
+	static char			GetEventArgForType( idTypeDef *type );
 };
 
 #endif /* !__SCRIPT_COMPILER_H__ */

--- a/game/script/Script_Interpreter.cpp
+++ b/game/script/Script_Interpreter.cpp
@@ -874,7 +874,7 @@ bool idInterpreter::MultiFrameEventInProgress( void ) const {
 idInterpreter::CallLibraryEvent
 ================
 */
-void idInterpreter::CallLibraryEvent( const function_t *func, int argsize ) {
+void idInterpreter::CallLibraryEvent( int libraryNumber, int functionNumber, int argsize ) {
 	int 				i;
 	int					j;
 	varEval_t			source;
@@ -883,7 +883,9 @@ void idInterpreter::CallLibraryEvent( const function_t *func, int argsize ) {
 	intptr_t			data[ D_EVENT_MAXARGS ];
 	const idEventDef	*evdef;
 	const char			*format;
-	Library*			library = gameLocal.GetLibrary();
+	Library*			libraryMgr = gameLocal.GetLibrary();
+	Library*			library = libraryMgr->libraries[libraryNumber];
+	const function_t*		func = library->GetFunction(functionNumber);
 
 	if ( !func ) {
 		Error( "NULL function" );
@@ -1221,7 +1223,7 @@ bool idInterpreter::Execute( void ) {
 			break;
 
 		case OP_LIBCALL:
-			CallLibraryEvent( st->a->value.functionPtr, st->b->value.argSize );
+			CallLibraryEvent( st->a->value.libraryNumber, st->a->value.virtualFunction, st->c->value.argSize );
 			break;
 
 		case OP_IFNOT:

--- a/game/script/Script_Interpreter.h
+++ b/game/script/Script_Interpreter.h
@@ -70,6 +70,7 @@ private:
 	void				LeaveFunction( idVarDef *returnDef );
 	void				CallEvent( const function_t *func, int argsize );
 	void				CallSysEvent( const function_t *func, int argsize );
+	void				CallLibraryEvent( const function_t *func, int argsize );
 
 public:
 	bool				doneProcessing;

--- a/game/script/Script_Interpreter.h
+++ b/game/script/Script_Interpreter.h
@@ -70,7 +70,7 @@ private:
 	void				LeaveFunction( idVarDef *returnDef );
 	void				CallEvent( const function_t *func, int argsize );
 	void				CallSysEvent( const function_t *func, int argsize );
-	void				CallLibraryEvent( const function_t *func, int argsize );
+	void				CallLibraryEvent( int libraryNumber, int functionNumber, int argsize );
 
 public:
 	bool				doneProcessing;

--- a/game/script/Script_Program.cpp
+++ b/game/script/Script_Program.cpp
@@ -29,6 +29,7 @@ idTypeDef	type_string( ev_string, &def_string, "string", MAX_STRING_LEN, NULL );
 idTypeDef	type_float( ev_float, &def_float, "float", sizeof(float), NULL );
 idTypeDef	type_vector( ev_vector, &def_vector, "vector", sizeof(idVec3), NULL );
 idTypeDef	type_entity( ev_entity, &def_entity, "entity", sizeof(int), NULL );					// stored as entity number pointer
+idTypeDef	type_library( ev_library, &def_library, "entity", sizeof(int), NULL );					// stored as library number pointer
 idTypeDef	type_field( ev_field, &def_field, "field", sizeof(int), NULL );
 idTypeDef	type_function( ev_function, &def_function, "function", sizeof(int), &type_void );
 idTypeDef	type_virtualfunction( ev_virtualfunction, &def_virtualfunction, "virtual function", sizeof(int), NULL );
@@ -45,6 +46,7 @@ idVarDef	def_string( &type_string );
 idVarDef	def_float( &type_float );
 idVarDef	def_vector( &type_vector );
 idVarDef	def_entity( &type_entity );
+idVarDef	def_library( &type_library );
 idVarDef	def_field( &type_field );
 idVarDef	def_function( &type_function );
 idVarDef	def_virtualfunction( &type_virtualfunction );
@@ -676,6 +678,10 @@ void idVarDef::SetValue( const eval_t &_value, bool constant ) {
 
 	case ev_entity :
 		*value.entityNumberPtr = _value.entity;
+		break;
+
+	case ev_library :
+		*value.libraryNumberPtr = _value.library;
 		break;
 
 	case ev_string :
@@ -1678,6 +1684,28 @@ void idProgram::SetEntity( const char *name, idEntity *ent ) {
 			*def->value.entityNumberPtr = 0;
 		} else {
 			*def->value.entityNumberPtr = ent->entityNumber + 1;
+		}
+	}
+}
+
+/*
+================
+idProgram::SetLibrary
+================
+*/
+void idProgram::SetLibrary( const char *name, Library *library ) {
+	idVarDef	*def;
+	idStr		defName( "@" );
+
+	defName += name;
+
+	def = GetDef( &type_entity, defName, &def_namespace );
+	if ( def && ( def->initialized != idVarDef::stackVariable ) ) {
+		// 0 is reserved for NULL entity
+		if ( !library ) {
+			*def->value.entityNumberPtr = 0;
+		} else {
+			*def->value.libraryNumberPtr = library->libraryNumber + 1;
 		}
 	}
 }

--- a/game/script/Script_Program.h
+++ b/game/script/Script_Program.h
@@ -26,6 +26,7 @@ class idEntity;
 class idThread;
 class idSaveGame;
 class idRestoreGame;
+class Library;
 
 #define MAX_STRING_LEN		128
 #define MAX_GLOBALS			(384 << 10)			// in bytes
@@ -33,7 +34,7 @@ class idRestoreGame;
 #define MAX_STATEMENTS		(80 << 10)			// statement_t - 18 bytes last I checked (stgatilov: it was never 18 bytes, now it is 40 bytes)
 
 typedef enum {
-	ev_error = -1, ev_void, ev_scriptevent, ev_namespace, ev_string, ev_float, ev_vector, ev_entity, ev_field, ev_function, ev_virtualfunction, ev_pointer, ev_object, ev_jumpoffset, ev_argsize, ev_boolean
+	ev_error = -1, ev_void, ev_scriptevent, ev_namespace, ev_string, ev_float, ev_vector, ev_entity, ev_field, ev_function, ev_virtualfunction, ev_pointer, ev_object, ev_jumpoffset, ev_argsize, ev_boolean, ev_library
 } etype_t;
 
 class function_t {
@@ -66,6 +67,7 @@ typedef union eval_s {
 	function_t			*function;
 	int 				_int;
 	int 				entity;
+	int				library;
 } eval_t;
 
 /***********************************************************************
@@ -286,6 +288,7 @@ typedef union varEval_s {
 	int 					*intPtr;
 	byte					*bytePtr;
 	int 					*entityNumberPtr;
+	int 					*libraryNumberPtr;
 	int						virtualFunction;
 	int						jumpOffset;
 	int						stackOffset;		// offset in stack for local variables
@@ -376,6 +379,7 @@ extern	idTypeDef	type_string;
 extern	idTypeDef	type_float;
 extern	idTypeDef	type_vector;
 extern	idTypeDef	type_entity;
+extern	idTypeDef	type_library;
 extern  idTypeDef	type_field;
 extern	idTypeDef	type_function;
 extern	idTypeDef	type_virtualfunction;
@@ -392,6 +396,7 @@ extern	idVarDef	def_string;
 extern	idVarDef	def_float;
 extern	idVarDef	def_vector;
 extern	idVarDef	def_entity;
+extern	idVarDef	def_library;
 extern	idVarDef	def_field;
 extern	idVarDef	def_function;
 extern	idVarDef	def_virtualfunction;
@@ -426,6 +431,7 @@ private:
 	idStrList									fileList;
 	idStr 										filename;
 	int											filenum;
+	bool										is_library;
 
 	idList<byte>								variables;
 	idList<byte>								variableDefaults;
@@ -511,6 +517,7 @@ public:
 	int											GetFunctionIndex( const function_t *func );
 
 	void										SetEntity( const char *name, idEntity *ent );
+	void										SetLibrary( const char *name, Library *library );
 
 	statement_t									*AllocStatement( void );
 	statement_t									&GetStatement( int index );

--- a/game/script/Script_Program.h
+++ b/game/script/Script_Program.h
@@ -34,7 +34,7 @@ class Library;
 #define MAX_STATEMENTS		(80 << 10)			// statement_t - 18 bytes last I checked (stgatilov: it was never 18 bytes, now it is 40 bytes)
 
 typedef enum {
-	ev_error = -1, ev_void, ev_scriptevent, ev_namespace, ev_string, ev_float, ev_vector, ev_entity, ev_field, ev_function, ev_virtualfunction, ev_pointer, ev_object, ev_jumpoffset, ev_argsize, ev_boolean, ev_library
+	ev_error = -1, ev_void, ev_scriptevent, ev_namespace, ev_externnamespace, ev_string, ev_float, ev_vector, ev_entity, ev_field, ev_function, ev_virtualfunction, ev_pointer, ev_object, ev_jumpoffset, ev_argsize, ev_boolean, ev_library, ev_libraryfunction
 } etype_t;
 
 class function_t {
@@ -67,7 +67,7 @@ typedef union eval_s {
 	function_t			*function;
 	int 				_int;
 	int 				entity;
-	int				library;
+	// RMV int				library;
 } eval_t;
 
 /***********************************************************************
@@ -288,7 +288,7 @@ typedef union varEval_s {
 	int 					*intPtr;
 	byte					*bytePtr;
 	int 					*entityNumberPtr;
-	int 					*libraryNumberPtr;
+	int 					libraryNumber;
 	int						virtualFunction;
 	int						jumpOffset;
 	int						stackOffset;		// offset in stack for local variables
@@ -375,11 +375,13 @@ private:
 extern	idTypeDef	type_void;
 extern	idTypeDef	type_scriptevent;
 extern	idTypeDef	type_namespace;
+extern	idTypeDef	type_externnamespace;
 extern	idTypeDef	type_string;
 extern	idTypeDef	type_float;
 extern	idTypeDef	type_vector;
 extern	idTypeDef	type_entity;
 extern	idTypeDef	type_library;
+extern	idTypeDef	type_libraryfunction;
 extern  idTypeDef	type_field;
 extern	idTypeDef	type_function;
 extern	idTypeDef	type_virtualfunction;
@@ -392,11 +394,13 @@ extern	idTypeDef	type_boolean;
 extern	idVarDef	def_void;
 extern	idVarDef	def_scriptevent;
 extern	idVarDef	def_namespace;
+extern	idVarDef	def_externnamespace;
 extern	idVarDef	def_string;
 extern	idVarDef	def_float;
 extern	idVarDef	def_vector;
 extern	idVarDef	def_entity;
 extern	idVarDef	def_library;
+extern	idVarDef	def_libraryfunction;
 extern	idVarDef	def_field;
 extern	idVarDef	def_function;
 extern	idVarDef	def_virtualfunction;
@@ -431,7 +435,6 @@ private:
 	idStrList									fileList;
 	idStr 										filename;
 	int											filenum;
-	bool										is_library;
 
 	idList<byte>								variables;
 	idList<byte>								variableDefaults;

--- a/idlib/Lexer.cpp
+++ b/idlib/Lexer.cpp
@@ -1667,6 +1667,8 @@ int idLexer::LoadFile( const char *filename, bool OSPath ) {
 	const char *tdmroot = cvarSystem->GetCVarString( "fs_basepath" );
 	displayFilename = idLexer::filename;
 	displayFilename.StripLeadingOnce(tdmroot);
+	filestem = displayFilename;
+	filestem.StripAbsoluteFileExtension();
 	libraryPath = "";
 
 	idLexer::buffer = buf;
@@ -1701,6 +1703,8 @@ int idLexer::LoadMemory( const char *ptr, int length, const char *name, int star
 	}
 	idLexer::filename = name;
 	idLexer::displayFilename = name;
+	idLexer::filestem = name;
+	idLexer::filestem.StripAbsoluteFileExtension();
 	idLexer::buffer = ptr;
 	idLexer::fileTime = 0;
 	idLexer::length = length;
@@ -1769,6 +1773,7 @@ idLexer::idLexer
 idLexer::idLexer( void ) {
 	idLexer::loaded = false;
 	idLexer::filename = "";
+	idLexer::filestem = "";
 	idLexer::flags = 0;
 	idLexer::SetPunctuations( NULL );
 	idLexer::allocated = false;
@@ -1790,6 +1795,7 @@ idLexer::idLexer
 idLexer::idLexer( int flags ) {
 	idLexer::loaded = false;
 	idLexer::filename = "";
+	idLexer::filestem = "";
 	idLexer::flags = flags;
 	idLexer::SetPunctuations( NULL );
 	idLexer::allocated = false;
@@ -1869,6 +1875,10 @@ idLexer::IsLibraryHeader
 */
 const bool idLexer::IsLibraryHeader( void ) const {
 	return idLexer::libraryPath != "";
+}
+
+const char* idLexer::GetLibraryPath( void ) {
+	return idLexer::libraryPath;
 }
 
 #pragma warning( pop )

--- a/idlib/Lexer.h
+++ b/idlib/Lexer.h
@@ -112,6 +112,7 @@ typedef enum {
 
 #define P_PRECOMP					51
 #define P_DOLLAR					52
+#define P_AT						53
 
 // punctuation
 typedef struct punctuation_s
@@ -307,6 +308,7 @@ public:
 
 					// set the base folder to load files from
 	static void		SetBaseFolder( const char *path );
+	const bool		IsLibraryHeader( void ) const;
 
 private:
 	int				loaded;					// set when a script file is loaded from file or memory
@@ -331,8 +333,10 @@ private:
 	idToken			token;					// available token
 	idLexer *		next;					// next script in a chain
 	bool			hadError;				// set by idLexer::Error, even if the error is supressed
+	bool			couldBeLibraryHeader;				// set by idLexer::Error, even if the error is supressed
 
 	static char		baseFolder[ 256 ];		// base folder to load files from
+	idStr			libraryPath;		// path to associated compiled library, or ""
 
 private:
 	void			CreatePunctuationTable( const punctuation_t *punctuations );

--- a/idlib/Lexer.h
+++ b/idlib/Lexer.h
@@ -289,6 +289,7 @@ public:
 	int				EndOfFile( void );
 					// returns the current filename
 	const char *	GetFileName( void );
+	const char *	GetFileStem( void );
 	const char *	GetDisplayFileName( void );
 					// get offset in script
 	const int		GetFileOffset( void );
@@ -309,11 +310,13 @@ public:
 					// set the base folder to load files from
 	static void		SetBaseFolder( const char *path );
 	const bool		IsLibraryHeader( void ) const;
+	const char*		GetLibraryPath( void );
 
 private:
 	int				loaded;					// set when a script file is loaded from file or memory
 	idStr			displayFilename;		// shortened file path for printing warnings
 	idStr			filename;				// file path of the script (absolute)
+	idStr			filestem;				// file path of the script (absolute)
 	int				allocated;				// true if buffer memory was allocated
 	const char *	buffer;					// buffer containing the script
 	const char *	script_p;				// current pointer in the script
@@ -353,6 +356,10 @@ private:
 
 ID_INLINE const char *idLexer::GetFileName( void ) {
 	return idLexer::filename;
+}
+
+ID_INLINE const char *idLexer::GetFileStem( void ) {
+	return idLexer::filestem;
 }
 
 ID_INLINE const char *idLexer::GetDisplayFileName( void ) {

--- a/idlib/Parser.cpp
+++ b/idlib/Parser.cpp
@@ -3364,3 +3364,16 @@ idParser::~idParser( void ) {
 	idParser::FreeSource( false );
 }
 
+
+const idStr idParser::GetLibraryPath( void ) const {
+	if ( idParser::scriptstack ) {
+		idStr path = scriptstack->GetFileName();
+		path.StripFilename();
+		path += "/";
+		path += idParser::scriptstack->GetLibraryPath();
+		return path;
+	}
+	else {
+		return "";
+	}
+}

--- a/idlib/Parser.h
+++ b/idlib/Parser.h
@@ -147,6 +147,7 @@ public:
 	int				GetFlags( void ) const;
 					// returns the current filename
 	const char *	GetFileName( void ) const;
+	const char *	GetFileStem( void ) const;
 	const char *	GetDisplayFileName( void ) const;
 					// get current offset in current script
 	const int		GetFileOffset( void ) const;
@@ -174,6 +175,7 @@ public:
 					// it is just concatenation of all replacement tokens (useful for constants)
 	idStr			GetDefineValueString(const char *name);
 	const bool		InLibraryHeader( void ) const;
+	const idStr		GetLibraryPath( void ) const;
 
 private:
 	int				loaded;						// set when a source file is loaded from file or memory
@@ -241,6 +243,15 @@ private:
 	int				DollarDirective_evalfloat( void );
 	int				ReadDollarDirective( void );
 };
+
+ID_INLINE const char *idParser::GetFileStem( void ) const {
+	if ( idParser::scriptstack ) {
+		return idParser::scriptstack->GetFileStem();
+	}
+	else {
+		return "";
+	}
+}
 
 ID_INLINE const char *idParser::GetFileName( void ) const {
 	if ( idParser::scriptstack ) {

--- a/idlib/Parser.h
+++ b/idlib/Parser.h
@@ -38,6 +38,8 @@ Project: The Dark Mod (http://www.thedarkmod.com/)
 #define INDENT_IFDEF			0x0008
 #define INDENT_IFNDEF			0x0010
 
+const char MAGIC_DEF_LIBRARY[] = "#library";
+
 // macro definitions
 typedef struct define_s {
 	char *			name;						// define name
@@ -171,6 +173,7 @@ public:
 					// stgatilov: returns string representation of macro value
 					// it is just concatenation of all replacement tokens (useful for constants)
 	idStr			GetDefineValueString(const char *name);
+	const bool		InLibraryHeader( void ) const;
 
 private:
 	int				loaded;						// set when a source file is loaded from file or memory
@@ -223,6 +226,7 @@ private:
 	int				Evaluate( int *intvalue, double *floatvalue, int integer );
 	int				DollarEvaluate( int *intvalue, double *floatvalue, int integer);
 	int				Directive_define( void );
+	int				Directive_library( void );
 	int				Directive_elif( void );
 	int				Directive_if( void );
 	int				Directive_line( void );
@@ -244,6 +248,15 @@ ID_INLINE const char *idParser::GetFileName( void ) const {
 	}
 	else {
 		return "";
+	}
+}
+
+ID_INLINE const bool idParser::InLibraryHeader( void ) const {
+	if ( idParser::scriptstack ) {
+		return idParser::scriptstack->IsLibraryHeader();
+	}
+	else {
+		return false;
 	}
 }
 


### PR DESCRIPTION
# Basic implementation for feedback

For more information, see [The Rusty Mod](https://github.com/philtweir/therustymod) Rust crate docs.

This PR is a demonstration implementation, but it is written to be (hopefully) fairly sensible and close enough that a modified, cleaned-up version, or subset of functionality, could be (moved to SVN and) merged.

## What does this do?

Adds several related pieces of functionality:

* ability to extend modder scripts via DLL/so
* scripting: a new `extern` keyword to represent a namespace that may not have been loaded yet, in the same add-on _or another third-party_ normal add-on 
* scripting: a directive `#library` to signify a library header file and locate the matching DLL/so
* scripting: library function signatures are check to match the `extern` definintion (as normal with namespaces) and the actual library definition when it loads 
* core: a new opcode for library calls
* core: a new `idClass` for Libraries (currently one for a manager implementation and individual libs, but could be split)
* core: new data-types for `type_library`,  `type_libraryfunction` and `type_externnamespace`
* libraries: a system is added that has a function table for each dynamically loaded library, and a manager class that has an `idList` of pointers
* libraries: if an add-on library function is still not initialized on startup but has been requested by a third-party add-on, 

## Design

Instead of including implementations, a scriptfile can open with `#library "libmymodpath.so"` (TODO: prefix only as FindDLL makes arch-independent). It should contain a single `extern mod_my_module { ... }` namespace that defines each of the functions present. To minimize additional indirection, library functions treated like virtual functions with a library number and a function number, and dynamically-loaded functions are mapped directly from Rust to the `eventCallback`

This has two main issues:

* we instantiate new `idClass` structures at runtime, and so the number of `eventMaps`, etc. can grow, which was clearly not anticipated
* every normal event call expects to have an `idClass` as the `this` parameter and, without reimplementing `Callbacks.cpp` or `Class.cpp` in a bigger way, either the library object must be passed out to Rust, a second level of indirection (and duplication of all possible callback signatures in Callback.cpp) is required, or the "static" functions must be faked into a pointer-to-member-function ABI - to reduce leakage of internal structures and complexity but keep it performant, I went for the latter

Also worth noting, the `extern` approach would allow a small number of DLL-based add-ons to be reused by multiple script-only traditional add-ons. This could allow things like web dashboard or LLM addons, which run their own daemon thread and process any non-trivial requests asynchronously for later pick-up by a range of scripts.

To avoid repetition, the Limitations are listed at the Rust module link above.