### PR TITLE
Some improvements and fixes, mostly from dhewm3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ CMakeSettings.json
 
 .svn/
 .vs/
-build/
+build*/
 ipch/
 Darkmod.log
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ if (UNIX)
 	# we want debug symbols even with Release builds
 	string(APPEND CMAKE_CXX_FLAGS_RELEASE_INIT "-g -ffast-math")
 	string(APPEND CMAKE_C_FLAGS_RELEASE_INIT "-g -ffast-math")
+
+	option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored compiler warnings/errors (GCC/Clang only; esp. useful with ninja)." OFF)
+	option(ASAN		"Enable GCC/Clang Adress Sanitizer (ASan)" OFF) # TODO: MSVC also supports this, somehow?
 elseif(MSVC)
 	set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
 endif()
@@ -60,13 +63,26 @@ if (UNIX)
 			-fno-omit-frame-pointer         # crashdumps!
 			-fmessage-length=0
 			-fvisibility=hidden
-			-fno-unsafe-math-optimizations
+			-fno-unsafe-math-optimizations # TODO: maybe get rid of -ffast-math
 			-std=c++14
 	)
 	# enable SSE2 if supported (mainly 32-bit x86)
 	check_cxx_compiler_flag(-msse2 MSSE2_SUPPORTED)
 	if (MSSE2_SUPPORTED)
 		add_compile_options(-msse2)
+	endif()
+
+	if(FORCE_COLORED_OUTPUT)
+		if(CMAKE_COMPILER_IS_GNUCC)
+		   add_compile_options (-fdiagnostics-color=always)
+		else() # clang, probably if (D3_COMPILER_IS_CLANG)
+		   add_compile_options (-fcolor-diagnostics)
+		endif ()
+	endif ()
+
+	if(ASAN)
+		# if this doesn't work, ASan might not be available on your platform, don't set ASAN then..
+		add_compile_options(-fsanitize=address)
 	endif()
 
 	# TODO: do we really want to keep using this
@@ -257,6 +273,11 @@ if (WIN32)
 	set_target_properties(TheDarkMod PROPERTIES WIN32_EXECUTABLE TRUE)
 elseif (UNIX)
 	target_link_libraries(TheDarkMod pthread dl stdc++fs X11 Xext Xxf86vm)
+
+	if(ASAN)
+		target_link_libraries(TheDarkMod -fsanitize=address)
+	endif()
+
 	# strip debug symbols from executable and put them into a separate symbols file
 	add_custom_command(
 			TARGET TheDarkMod POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ if(NOT is_multi_config AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 if (UNIX)
-	# we want debug symbols even with Release builds
-	string(APPEND CMAKE_CXX_FLAGS_RELEASE_INIT "-g -ffast-math")
-	string(APPEND CMAKE_C_FLAGS_RELEASE_INIT "-g -ffast-math")
+	# we want debug symbols even with Release builds; enable the "good parts" of -ffast-math (which is not to be trusted)
+	string(APPEND CMAKE_CXX_FLAGS_RELEASE_INIT "-g -fno-math-errno -fno-trapping-math -ffinite-math-only")
+	string(APPEND CMAKE_C_FLAGS_RELEASE_INIT "-g -fno-math-errno -fno-trapping-math -ffinite-math-only")
 
 	option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored compiler warnings/errors (GCC/Clang only; esp. useful with ninja)." OFF)
 	option(ASAN		"Enable GCC/Clang Adress Sanitizer (ASan)" OFF) # TODO: MSVC also supports this, somehow?
@@ -68,7 +68,6 @@ if (UNIX)
 			-fno-omit-frame-pointer         # crashdumps!
 			-fmessage-length=0
 			-fvisibility=hidden
-			-fno-unsafe-math-optimizations # TODO: maybe get rid of -ffast-math
 			-std=c++14
 	)
 	# enable SSE2 if supported (mainly 32-bit x86)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ if (UNIX)
 			-Woverloaded-virtual            # almost-overriding virtual functions is dangerous for us
 			-Wsuggest-override              # recommend using "override" keyword
 	)
+	CHECK_CXX_COMPILER_FLAG("-Wdangling-reference" cxx_has_Wdangling_reference)
+	if(cxx_has_Wdangling_reference)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=dangling-reference")
+	endif()
+
 	# configure other compile options
 	add_compile_options(
 			-pipe
@@ -70,11 +75,6 @@ if (UNIX)
 	check_cxx_compiler_flag(-msse2 MSSE2_SUPPORTED)
 	if (MSSE2_SUPPORTED)
 		add_compile_options(-msse2)
-	endif()
-
-	CHECK_CXX_COMPILER_FLAG("-Wdangling-reference" cxx_has_Wdangling_reference)
-	if(cxx_has_Wdangling_reference)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=dangling-reference")
 	endif()
 
 	if(FORCE_COLORED_OUTPUT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ if (UNIX)
 		add_compile_options(-msse2)
 	endif()
 
+	CHECK_CXX_COMPILER_FLAG("-Wdangling-reference" cxx_has_Wdangling_reference)
+	if(cxx_has_Wdangling_reference)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=dangling-reference")
+	endif()
+
 	if(FORCE_COLORED_OUTPUT)
 		if(CMAKE_COMPILER_IS_GNUCC)
 		   add_compile_options (-fdiagnostics-color=always)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,20 @@ if (UNIX)
 		add_compile_options(-msse2)
 	endif()
 
+	# don't mess up math code with useless FMA "optimizations"
+	# (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100839)
+	# see also https://github.com/dhewm/dhewm3/commit/2521c3dfdb87c9261f69615ab7ecc241c1046bb4
+	# and https://github.com/dhewm/dhewm3/issues/147
+	# and https://github.com/RobertBeckebans/RBDOOM-3-BFG/issues/436#issuecomment-850930254 (and following)
+	CHECK_CXX_COMPILER_FLAG("-ffp-contract=off" cxx_has_fp-contract)
+	if(cxx_has_fp-contract)
+		add_compile_options(-ffp-contract=off)
+	endif()
+
 	if(FORCE_COLORED_OUTPUT)
 		if(CMAKE_COMPILER_IS_GNUCC)
 		   add_compile_options (-fdiagnostics-color=always)
-		else() # clang, probably if (D3_COMPILER_IS_CLANG)
+		else() # clang, probably
 		   add_compile_options (-fcolor-diagnostics)
 		endif ()
 	endif ()

--- a/game/ai/AI.cpp
+++ b/game/ai/AI.cpp
@@ -5051,7 +5051,7 @@ bool idAI::GetMovePos(idVec3 &seekPos)
 				// angua: check whether there is a door in the path
 				if (path.firstDoor != NULL)
 				{
-					const idVec3& doorOrg = path.firstDoor->GetClosedBox().GetCenter(); // grayman #3755 - use door center, not origin
+					const idVec3 doorOrg = path.firstDoor->GetClosedBox().GetCenter(); // grayman #3755 - use door center, not origin
 					//const idVec3& doorOrg = path.firstDoor->GetPhysics()->GetOrigin();
 					const idVec3& org = GetPhysics()->GetOrigin();
 					idVec3 dir = doorOrg - org;

--- a/game/ai/Tasks/HandleDoorTask.cpp
+++ b/game/ai/Tasks/HandleDoorTask.cpp
@@ -544,10 +544,10 @@ bool HandleDoorTask::Perform(Subsystem& subsystem)
 	int queuePos = frobDoor->GetUserManager().GetIndex(owner); // grayman #2345
 
 	const idVec3& frobDoorOrg = frobDoor->GetPhysics()->GetOrigin();
-	const idVec3& openPos = frobDoorOrg + frobDoor->GetOpenPos();
-	const idVec3& closedPos = frobDoorOrg + frobDoor->GetClosedPos();
-	const idVec3& centerPos = frobDoor->GetClosedBox().GetCenter(); // grayman #1327
-	const idVec3& currentPos = frobDoor->GetCurrentPos(); // grayman #3523
+	const idVec3 openPos = frobDoorOrg + frobDoor->GetOpenPos();
+	const idVec3 closedPos = frobDoorOrg + frobDoor->GetClosedPos();
+	const idVec3 centerPos = frobDoor->GetClosedBox().GetCenter(); // grayman #1327
+	const idVec3 currentPos = frobDoor->GetCurrentPos(); // grayman #3523
 	//gameRenderWorld->DebugArrow(colorCyan, currentPos, currentPos + idVec3(0, 0, 20), 2, 1000);
 
 	// if our current door is part of a double door, this is the other part.

--- a/game/gamesys/Class.cpp
+++ b/game/gamesys/Class.cpp
@@ -452,11 +452,11 @@ idClass::new
 #endif
 
 void * idClass::operator new( size_t s ) {
-	int *p;
+	intptr_t *p;
 
-	s += sizeof( int );
-	p = (int *)Mem_Alloc(static_cast<int>(s));
-	*p = static_cast<int>(s);
+	s += sizeof( intptr_t );
+	p = (intptr_t *)Mem_Alloc( s );
+	*p = s;
 	memused += static_cast<int>(s);
 	numobjects++;
 
@@ -475,11 +475,11 @@ void * idClass::operator new( size_t s ) {
 }
 
 void * idClass::operator new( size_t s, int, int, char *, int ) {
-	int *p;
+	intptr_t *p;
 
-	s += sizeof( int );
-	p = (int *)Mem_Alloc(static_cast<int>(s));
-	*p = static_cast<int>(s);
+	s += sizeof( intptr_t );
+	p = (intptr_t *)Mem_Alloc( s );
+	*p = s;
 	memused += static_cast<int>(s);
 	numobjects++;
 
@@ -507,24 +507,24 @@ idClass::delete
 ================
 */
 void idClass::operator delete( void *ptr ) {
-	int *p;
+	intptr_t *p;
 
 	if ( ptr ) {
-		p = ( ( int * )ptr ) - 1;
+		p = ( ( intptr_t * )ptr ) - 1;
 		memused -= *p;
 		numobjects--;
-        Mem_Free( p );
+		Mem_Free( p );
 	}
 }
 
 void idClass::operator delete( void *ptr, int, int, char *, int ) {
-	int *p;
+	intptr_t *p;
 
 	if ( ptr ) {
-		p = ( ( int * )ptr ) - 1;
+		p = ( ( intptr_t * )ptr ) - 1;
 		memused -= *p;
 		numobjects--;
-        Mem_Free( p );
+		Mem_Free( p );
 	}
 }
 

--- a/sys/cmake/ucm.cmake
+++ b/sys/cmake/ucm.cmake
@@ -10,7 +10,7 @@
 # The documentation can be found at the library's page:
 # https://github.com/onqtam/ucm
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 include(CMakeParseArguments)
 


### PR DESCRIPTION
* Some GCC/Clang specific compiler options
    - CMake option to enable ASan
    - CMake option to enforce colored compiler messages
    - Safer options for floating point math
* fixed alignment of memory returned by `idClass::operator new()` (i.e. whenever an entity or other subtype of idClass is allocated with `new`) on 64bit systems by aligning to `intptr_t` (8byte == 64bit on 64bit systems) instead of `int` (4byte == 32bit even on 64bit systems)
* Fix references pointing to invalid stack memory (temporaries that went out of scope)
    - Enable GCC warning about this (if supported by the used GCC version) as error (=> if GCC detects this issue compilation fails). I think GCC 13 and newer support it.