### PR TITLE
Ported the Script Debugger from dhewm3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,18 @@ if (WITH_TOOLS)
 	)
 else ()
 	ucm_add_files("tools/guied/GEWindowWrapper_stub.cpp" TO TDM_SOURCE_FILES)
+	# cross-platform debugger server
+	ucm_add_files(
+		tools/debugger/DebuggerBreakpoint.h
+		tools/debugger/DebuggerBreakpoint.cpp
+		tools/debugger/DebuggerServer.h
+		tools/debugger/DebuggerServer.cpp
+		tools/debugger/DebuggerScript.h
+		tools/debugger/DebuggerScript.cpp
+		tools/debugger/DebuggerMessages.h
+		tools/debugger/debugger.cpp
+		TO TDM_SOURCE_FILES
+	)
 	add_compile_definitions(NO_MFC)
 endif ()
 

--- a/framework/CVarSystem.cpp
+++ b/framework/CVarSystem.cpp
@@ -149,7 +149,7 @@ void idCVar::UpdateValue( void ) {
 				clamped = true;
 			}
 		}
-		if ( clamped || !idStr::IsNumeric( value ) || idStr::FindChar( value, '.' ) ) {
+		if ( clamped || !idStr::IsNumeric( value ) || idStr::FindChar( value, '.' ) != -1 ) {
 			*pActiveValue = idStr( integerValue );
 			value = pActiveValue->c_str();
 		}

--- a/framework/Common.cpp
+++ b/framework/Common.cpp
@@ -804,7 +804,7 @@ void idCommonLocal::DoError( const char *msg, int code ) {
 	errorList.AddUnique( msg );
 
 	// Dont shut down the session for gui editor or debugger
-	if( !( com_editors & ( EDITOR_GUI ) ) ) {
+	if ( !( com_editors & ( EDITOR_GUI | EDITOR_DEBUGGER ) ) ) {
 		session->Stop();
 	}
 
@@ -813,7 +813,7 @@ void idCommonLocal::DoError( const char *msg, int code ) {
 		throw idException( msg );
 		// The gui editor doesnt want thing to com_error so it handles exceptions instead
 	}
-	else if( com_editors & ( EDITOR_GUI ) ) {
+	} else if( com_editors & ( EDITOR_GUI | EDITOR_DEBUGGER ) ) {
 		com_errorEntered = 0;
 		throw idException( msg );
 	}
@@ -1161,6 +1161,9 @@ void idCommonLocal::CheckToolMode( void ) {
 		if ( !idStr::Icmp( com_consoleLines[ i ].Argv(0), "guieditor" ) ) {
 			com_editors |= EDITOR_GUI;
 		}
+		else if ( !idStr::Icmp( com_consoleLines[ i ].Argv(0), "debugger" ) ) {
+			com_editors |= EDITOR_DEBUGGER;
+		}
 		else if ( !idStr::Icmp( com_consoleLines[ i ].Argv(0), "editor" ) ) {
 			com_editors |= EDITOR_RADIANT;
 		}
@@ -1391,6 +1394,19 @@ Com_Editor_f
 */
 static void Com_Editor_f( const idCmdArgs &args ) {
 	RadiantInit();
+}
+
+/*
+=============
+Com_ScriptDebugger_f
+=============
+*/
+static void Com_ScriptDebugger_f( const idCmdArgs &args ) {
+	// Make sure it wasnt on the command line
+	if ( !( com_editors & EDITOR_DEBUGGER ) ) {
+		common->Printf( "Script debugger is currently disabled\n" );
+		// DebuggerClientLaunch();
+	}
 }
 
 /*
@@ -2335,6 +2351,7 @@ void idCommonLocal::InitCommands( void ) {
 	cmdSystem->AddCommand( "editParticles", Com_EditParticles_f, CMD_FL_TOOL, "launches the in-game Particle Editor" );
 	cmdSystem->AddCommand( "editScripts", Com_EditScripts_f, CMD_FL_TOOL, "launches the in-game Script Editor" );
 	cmdSystem->AddCommand( "editGUIs", Com_EditGUIs_f, CMD_FL_TOOL, "launches the GUI Editor" );
+	cmdSystem->AddCommand( "debugger", Com_ScriptDebugger_f, CMD_FL_TOOL, "launches the Script Debugger" );
 
 	//BSM Nerve: Add support for the material editor
 	cmdSystem->AddCommand( "materialEditor", Com_MaterialEditor_f, CMD_FL_TOOL, "launches the Material Editor" );

--- a/framework/Common.cpp
+++ b/framework/Common.cpp
@@ -120,8 +120,12 @@ idCVar com_makingBuild( "com_makingBuild", "0", CVAR_BOOL | CVAR_SYSTEM, "1 when
 idCVar com_updateLoadSize( "com_updateLoadSize", "0", CVAR_BOOL | CVAR_SYSTEM | CVAR_NOCHEAT, "update the load size after loading a map" );
 //idCVar com_videoRam( "com_videoRam", "128", CVAR_INTEGER | CVAR_SYSTEM | CVAR_NOCHEAT | CVAR_ARCHIVE, "holds the last amount of detected video ram" );
 
-idCVar com_product_lang_ext( "com_product_lang_ext", "1", CVAR_INTEGER | CVAR_SYSTEM | CVAR_ARCHIVE, "Extension to use when creating language files." );
+// DG: script debugger from dhewm3
+idCVar com_enableDebuggerServer( "com_enableDebuggerServer", "0", CVAR_BOOL | CVAR_SYSTEM, "toggle debugger server and try to connect to com_dbgClientAdr" );
+idCVar com_dbgClientAdr( "com_dbgClientAdr", "localhost", CVAR_SYSTEM | CVAR_ARCHIVE, "debuggerApp client address" );
+idCVar com_dbgServerAdr( "com_dbgServerAdr", "localhost", CVAR_SYSTEM | CVAR_ARCHIVE, "debugger server address" );
 
+idCVar com_product_lang_ext( "com_product_lang_ext", "1", CVAR_INTEGER | CVAR_SYSTEM | CVAR_ARCHIVE, "Extension to use when creating language files." );
 
 // com_speeds times
 int				time_gameFrame;
@@ -420,8 +424,19 @@ void idCommonLocal::VPrintf( const char *fmt, va_list args ) {
 	// echo to dedicated console and early console
 	Sys_Printf( "%s", msg );
 
-	// print to script debugger server
-	// DebuggerServerPrint( msg );
+	if ( com_enableDebuggerServer.GetBool( ) )      {
+		// print to script debugger server
+		if ( com_editors & EDITOR_DEBUGGER ) {
+			DebuggerServerPrint( msg );
+		} else {
+			// only echo to dedicated console and early console when debugger is not running so no
+			// deadlocks occur if engine functions called from the debuggerthread trace stuff..
+			Sys_Printf( "%s", msg );
+		}
+	} else {
+		// echo to dedicated console and early console
+		Sys_Printf( "%s", msg );
+	}
 
 #if 0	// !@#
 #if defined(_DEBUG) && defined(WIN32)
@@ -812,7 +827,6 @@ void idCommonLocal::DoError( const char *msg, int code ) {
 		com_errorEntered = 0;
 		throw idException( msg );
 		// The gui editor doesnt want thing to com_error so it handles exceptions instead
-	}
 	} else if( com_editors & ( EDITOR_GUI | EDITOR_DEBUGGER ) ) {
 		com_errorEntered = 0;
 		throw idException( msg );
@@ -1404,8 +1418,12 @@ Com_ScriptDebugger_f
 static void Com_ScriptDebugger_f( const idCmdArgs &args ) {
 	// Make sure it wasnt on the command line
 	if ( !( com_editors & EDITOR_DEBUGGER ) ) {
-		common->Printf( "Script debugger is currently disabled\n" );
-		// DebuggerClientLaunch();
+		// start debugger server if needed
+		if ( !com_enableDebuggerServer.GetBool() )
+			com_enableDebuggerServer.SetBool( true );
+
+		// start debugger client.
+		DebuggerClientLaunch();
 	}
 }
 
@@ -2450,6 +2468,14 @@ void idCommonLocal::Frame( void ) {
 			InitSIMD();
 		}
 
+		if ( com_enableDebuggerServer.IsModified() ) {
+			if ( com_enableDebuggerServer.GetBool() ) {
+				DebuggerServerInit();
+			} else {
+				DebuggerServerShutdown();
+			}
+		}
+
 		eventLoop->RunEventLoop();
 
 		static int64_t com_frameTimeMicro = 0;		//same as com_frameTime, but in microseconds
@@ -3009,13 +3035,14 @@ void idCommonLocal::InitGame( void )
 	// initialize the user interfaces
 	uiManager->Init();
 
-	// startup the script debugger
-	// DebuggerServerInit();
-
 	// load the game dll
 	LoadGameDLL();
 	// stgatilov #5661: notify MissionManager about already accepted new FMs
 	gameLocal.m_MissionManager->AddToNewModList(newModsList);
+
+	// startup the script debugger
+	if ( com_enableDebuggerServer.GetBool( ) )
+		DebuggerServerInit();
 	
 	// init the session
 	session->Init();
@@ -3041,7 +3068,8 @@ void idCommonLocal::ShutdownGame( bool reloading ) {
 	}
 
 	// shutdown the script debugger
-	// DebuggerServerShutdown();
+	if ( com_enableDebuggerServer.GetBool() )
+		DebuggerServerShutdown();
 
 	// shut down the session
 	session->Shutdown();

--- a/framework/Common.cpp
+++ b/framework/Common.cpp
@@ -421,10 +421,7 @@ void idCommonLocal::VPrintf( const char *fmt, va_list args ) {
 	// remove any color codes
 	idStr::RemoveColors( msg );
 
-	// echo to dedicated console and early console
-	Sys_Printf( "%s", msg );
-
-	if ( com_enableDebuggerServer.GetBool( ) )      {
+	if ( com_enableDebuggerServer.GetBool( ) ) {
 		// print to script debugger server
 		if ( com_editors & EDITOR_DEBUGGER ) {
 			DebuggerServerPrint( msg );

--- a/framework/Common.h
+++ b/framework/Common.h
@@ -31,7 +31,7 @@ typedef enum {
 	EDITOR_NONE					= 0,
 	EDITOR_RADIANT				= BIT(1),
 	EDITOR_GUI					= BIT(2),
-	//EDITOR_DEBUGGER				= BIT(3),
+	EDITOR_DEBUGGER				= BIT(3),
 	EDITOR_SCRIPT				= BIT(4),
 	EDITOR_LIGHT				= BIT(5),
 	EDITOR_SOUND				= BIT(6),

--- a/framework/Common.h
+++ b/framework/Common.h
@@ -67,6 +67,10 @@ extern idCVar		com_updateLoadSize;
 extern idCVar		com_timescale;
 //extern idCVar		com_videoRam;
 
+extern idCVar		com_enableDebuggerServer;
+extern idCVar		com_dbgClientAdr;
+extern idCVar		com_dbgServerAdr;
+
 extern int			time_gameFrame;			// game logic time
 extern int			time_gameDraw;			// game present time
 extern int			time_frontend;			// renderer frontend time

--- a/framework/FileSystem.cpp
+++ b/framework/FileSystem.cpp
@@ -774,10 +774,21 @@ const char *idFileSystemLocal::OSPathToRelativePath( const char *OSPath ) {
     }
 
 	if ( base ) {
-		s = strstr( base, "/" );
-		if ( !s ) {
-			s = strstr( base, "\\" );
-		} 
+		// DG: on Windows base might look like "base\\pak008.pk4/script/doom_util.script"
+		//     while on Linux it'll be more like "base/pak008.pk4/script/doom_util.script"
+		//     I /think/ we want to get rid of the bla.pk4 part, at least that's what happens implicitly on Windows
+		//     (I hope these problems don't exist if the file is not from a .pk4, so that case is handled like before)
+		// (from dhewm3 commit 40fa8a7 to make script debugger on Linux work)
+		s = strstr( base, ".pk4/" );
+		if ( s != NULL ) {
+			s += 4; // skip ".pk4", but *not* the following '/', that'll be skipped below
+		} else {
+			s = strchr( base, '/' );
+			if ( s == NULL ) {
+				s = strchr( base, '\\' );
+			}
+		}
+
 		if ( s ) {
 			strcpy( relativePath, s + 1 );
 			if ( fs_debug.GetInteger() > 1 ) {

--- a/game/Game.h
+++ b/game/Game.h
@@ -194,6 +194,11 @@ class idMD5Anim;
 typedef struct renderLight_s renderLight_t;
 typedef struct renderEntity_s renderEntity_t;
 class idRenderModel;
+class idThread;
+class function_t;
+class idProgram;
+class idInterpreter;
+typedef struct prstack_s prstack_t;
 
 // FIXME: this interface needs to be reworked but it properly separates code for the time being
 class idGameEdit {
@@ -282,6 +287,36 @@ public:
 	virtual void				MapRemoveEntity( const char *name ) const;
 	virtual void				MapEntityTranslate( const char *name, const idVec3 &v ) const;
 
+	// ##### Script Debugger #####
+
+	// IdProgram
+	virtual void				GetLoadedScripts( idStrList ** result );
+	virtual bool				IsLineCode( const char* filename, int linenumber) const;
+	virtual const char *		GetFilenameForStatement( idProgram* program, int index ) const;
+	virtual int					GetLineNumberForStatement( idProgram* program, int index ) const;
+
+	// idInterpreter
+	virtual bool				CheckForBreakPointHit( const idInterpreter* interpreter, const function_t* function1, const function_t* function2, int depth ) const;
+	virtual bool				ReturnedFromFunction( const idProgram* program, const idInterpreter* interpreter, int index ) const;
+	virtual bool				GetRegisterValue( const idInterpreter* interpreter, const char* name, idStr& out, int scopeDepth ) const;
+	virtual const idThread*		GetThread( const idInterpreter* interpreter ) const;
+	virtual int					GetInterpreterCallStackDepth( const idInterpreter* interpreter );
+	virtual const function_t*	GetInterpreterCallStackFunction( const idInterpreter* interpreter, int stackDepth = -1 );
+
+	// IdThread
+	virtual const char *		ThreadGetName( const idThread* thread ) const;
+	virtual int					ThreadGetNum( const idThread* thread ) const;
+	virtual bool				ThreadIsDoneProcessing( const idThread* thread ) const;
+	virtual bool				ThreadIsWaiting( const idThread* thread ) const;
+	virtual bool				ThreadIsDying( const idThread* thread ) const;
+	virtual int					GetTotalScriptThreads( ) const;
+	virtual const idThread*		GetThreadByIndex( int index ) const;
+
+	// MSG helpers
+	virtual void				MSG_WriteThreadInfo( idBitMsg* msg, const idThread* thread, const idInterpreter* interpreter );
+	virtual void				MSG_WriteCallstackFunc( idBitMsg* msg, const prstack_t* stack, const idProgram* program, int instructionPtr );
+	virtual void				MSG_WriteInterpreterInfo( idBitMsg* msg, const idInterpreter* interpreter, const idProgram* program, int instructionPtr );
+	virtual void				MSG_WriteScriptList( idBitMsg* msg );
 };
 
 extern idGameEdit *				gameEdit;

--- a/game/GameEdit.cpp
+++ b/game/GameEdit.cpp
@@ -1211,3 +1211,64 @@ void idGameEdit::MapEntityTranslate( const char *name, const idVec3 &v ) const {
 		}
 	}
 }
+
+/***********************************************************************
+
+  Debugger
+
+***********************************************************************/
+
+bool idGameEdit::IsLineCode(const char* filename, int linenumber) const
+{
+	idStr fileStr;
+	idProgram* program = &gameLocal.program;
+	for (int i = 0; i < program->NumStatements(); i++)
+	{
+		fileStr = program->GetFilename(program->GetStatement(i).file);
+		fileStr.BackSlashesToSlashes();
+
+		if (strcmp(filename, fileStr.c_str()) == 0
+			&& program->GetStatement(i).linenumber == linenumber
+			)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+void idGameEdit::GetLoadedScripts( idStrList** result )
+{
+	(*result)->Clear();
+	idProgram* program = &gameLocal.program;
+
+	for (int i = 0; i < program->NumFilenames(); i++)
+	{
+		(*result)->AddUnique( idStr(program->GetFilename( i )) );
+	}
+}
+
+void idGameEdit::MSG_WriteScriptList( idBitMsg* msg)
+{
+	idProgram* program = &gameLocal.program;
+
+	msg->WriteInt( program->NumFilenames() );
+	for (int i = 0; i < program->NumFilenames(); i++)
+	{
+		idStr file = program->GetFilename(i);
+		//fix this. it seams that scripts triggered by the runtime are stored with a wrong path
+		//the use // instead of '\'
+		file.BackSlashesToSlashes();
+		msg->WriteString(file);
+	}
+}
+
+const char*idGameEdit::GetFilenameForStatement(idProgram* program, int index) const
+{
+	return program->GetFilenameForStatement(index);
+}
+
+int idGameEdit::GetLineNumberForStatement(idProgram* program, int index) const
+{
+	return program->GetLineNumberForStatement(index);
+}

--- a/game/script/Script_Interpreter.cpp
+++ b/game/script/Script_Interpreter.cpp
@@ -20,6 +20,11 @@ Project: The Dark Mod (http://www.thedarkmod.com/)
 
 #include "../Game_local.h"
 
+#include "framework/FileSystem.h"
+
+// DG: debugger support (a bit hacky, when doing it this way it only works if game-"DLL" is statically linked)
+extern void DebuggerServerCheckBreakpoint( idInterpreter *interpreter, idProgram *program, int instructionPointer );
+
 /*
 ================
 idInterpreter::idInterpreter()
@@ -190,7 +195,6 @@ idInterpreter::GetRegisterValue
 Returns a string representation of the value of the register.  This is 
 used primarily for the debugger and debugging
 
-//FIXME:  This is pretty much wrong.  won't access data in most situations.
 ================
 */
 bool idInterpreter::GetRegisterValue( const char *name, idStr &out, int scopeDepth ) {
@@ -198,9 +202,9 @@ bool idInterpreter::GetRegisterValue( const char *name, idStr &out, int scopeDep
 	idVarDef		*d;
 	char			funcObject[ 1024 ];
 	char			*funcName;
-	const idVarDef	*scope;
+	const idVarDef	*scope = NULL;
+	const idVarDef	*scopeObj;
 	const idTypeDef	*field;
-	const idScriptObject *obj;
 	const function_t *func;
 
 	out.Clear();
@@ -222,33 +226,42 @@ bool idInterpreter::GetRegisterValue( const char *name, idStr &out, int scopeDep
 	funcName = strstr( funcObject, "::" );
 	if ( funcName ) {
 		*funcName = '\0';
-		scope = gameLocal.program.GetDef( NULL, funcObject, &def_namespace );
+		scopeObj = gameLocal.program.GetDef( NULL, funcObject, &def_namespace );
 		funcName += 2;
+		if ( scopeObj )
+		{
+			scope = gameLocal.program.GetDef( NULL, funcName, scopeObj );
+		}
 	} else {
 		funcName = funcObject;
-		scope = &def_namespace;
+		scope = gameLocal.program.GetDef( NULL, func->Name(), &def_namespace );
+		scopeObj = NULL;
 	}
 
-	// Get the function from the object
-	d = gameLocal.program.GetDef( NULL, funcName, scope );
-	if ( !d ) {
+	if ( !scope )
+	{
 		return false;
 	}
 	
-	// Get the variable itself and check various namespaces
-	d = gameLocal.program.GetDef( NULL, name, d );
-	if ( !d ) {
-		if ( scope == &def_namespace ) {
-			return false;
-		}
-		
-		d = gameLocal.program.GetDef( NULL, name, scope );
-		if ( !d ) {
-			d = gameLocal.program.GetDef( NULL, name, &def_namespace );
-			if ( !d ) {
-				return false;
+	d = gameLocal.program.GetDef( NULL, name, scope );
+
+	// Check the objects for it if it wasnt local to the function
+	if ( !d )
+	{
+		for ( ; scopeObj && scopeObj->TypeDef()->SuperClass(); scopeObj = scopeObj->TypeDef()->SuperClass()->def )
+		{
+			d = gameLocal.program.GetDef( NULL, name, scopeObj );
+			if ( d )
+			{
+				break;
 			}
 		}
+	}
+
+	if ( !d )
+	{
+		out = "???";
+		return false;
 	}
 		
 	reg = GetVariable( d );
@@ -281,14 +294,24 @@ bool idInterpreter::GetRegisterValue( const char *name, idStr &out, int scopeDep
 		break;
 
 	case ev_field:
+	{
+		idEntity*		entity;
+		idScriptObject*	obj;
+
 		if ( scope == &def_namespace ) {
 			// should never happen, but handle it safely anyway
 			return false;
 		}
 
-		field = scope->TypeDef()->GetParmType( reg.ptrOffset )->FieldType();
-		obj   = *reinterpret_cast<const idScriptObject **>( &localstack[ callStack[ callStackDepth ].stackbase ] );
-		if ( !field || !obj ) {
+		field  = d->TypeDef()->FieldType();
+		entity = GetEntity ( *((int*)&localstack[ localstackBase ]) );
+		if ( !entity || !field )
+		{
+			return false;
+		}
+
+		obj = &entity->scriptObject;
+		if ( !obj ) {
 			return false;
 		}
 								
@@ -301,10 +324,25 @@ bool idInterpreter::GetRegisterValue( const char *name, idStr &out, int scopeDep
 			out = va( "%g", *( reinterpret_cast<float *>( &obj->data[ reg.ptrOffset ] ) ) );
 			return true;
 
+		case ev_string:	{
+			const char* str;
+			str = reinterpret_cast<const char*>( &obj->data[ reg.ptrOffset ] );
+			if ( !str ) {
+				out = "\"\"";
+			} else {
+				out  = "\"";
+				out += str;
+				out += "\"";
+			}
+			return true;
+		}
+
 		default:
 			return false;
 		}
+
 		break;
+	}
 
 	case ev_string:
 		if ( reg.stringPtr ) {
@@ -952,6 +990,16 @@ void idInterpreter::CallSysEvent( const function_t *func, int argsize ) {
 	popParms = 0;
 }
 
+// DG: for script debugger support
+static bool updateGameDebugger( idInterpreter *interpreter, idProgram *program, int instructionPointer ) {
+	// early out if debugger server isn't active
+	if ( (com_editors & EDITOR_DEBUGGER) == 0 || interpreter == NULL || program == NULL ) {
+		return false;
+	}
+	DebuggerServerCheckBreakpoint( interpreter, program, instructionPointer );
+	return true;
+}
+
 /*
 ====================
 idInterpreter::Execute
@@ -1004,6 +1052,19 @@ bool idInterpreter::Execute( void ) {
 
 		// next statement
 		st = &gameLocal.program.GetStatement( instructionPointer );
+
+		if ( !updateGameDebugger( this, &gameLocal.program, instructionPointer )
+			&& g_debugScript.GetBool( ) )
+		{
+			static int lastLineNumber = -1;
+			if ( lastLineNumber != gameLocal.program.GetStatement ( instructionPointer ).linenumber ) {
+				gameLocal.Printf ( "%s (%d)\n",
+					gameLocal.program.GetFilename ( gameLocal.program.GetStatement ( instructionPointer ).file ),
+					gameLocal.program.GetStatement ( instructionPointer ).linenumber
+					);
+				lastLineNumber = gameLocal.program.GetStatement ( instructionPointer ).linenumber;
+			}
+		}
 
 		switch( st->op ) {
 		case OP_RETURN:
@@ -2062,3 +2123,99 @@ Quit:
 	return rc;
 }
 
+// DG: all the following are for Script Debugger (ported from dhewm3)
+
+bool idGameEdit::CheckForBreakPointHit(const idInterpreter* interpreter, const function_t* function1, const function_t* function2, int depth) const
+{
+	return ( ( interpreter->GetCurrentFunction ( ) == function1 ||
+			   interpreter->GetCurrentFunction ( ) == function2)&&
+			 ( interpreter->GetCallstackDepth ( )  <= depth) );
+}
+
+bool idGameEdit::ReturnedFromFunction(const idProgram* program, const idInterpreter* interpreter, int index) const
+{
+
+	return ( const_cast<idProgram*>(program)->GetStatement(index).op == OP_RETURN && interpreter->GetCallstackDepth ( ) <= 1 );
+}
+
+bool idGameEdit::GetRegisterValue(const idInterpreter* interpreter, const char* name, idStr& out, int scopeDepth) const
+{
+	return const_cast<idInterpreter*>(interpreter)->GetRegisterValue(name, out, scopeDepth);
+}
+
+const idThread*idGameEdit::GetThread(const idInterpreter* interpreter) const
+{
+	return interpreter->GetThread();
+}
+
+void idGameEdit::MSG_WriteCallstackFunc(idBitMsg* msg, const prstack_t* stack, const idProgram * program, int instructionPtr)
+{
+	const statement_t*	st;
+	const function_t*	func;
+
+	func  = stack->f;
+
+	// If the function is unknown then just fill in with default data.
+	if ( !func )
+	{
+		msg->WriteString ( "<UNKNOWN>" );
+		msg->WriteString ( "<UNKNOWN>" );
+		msg->WriteInt ( 0 );
+		return;
+	}
+	else
+	{
+		msg->WriteString ( va("%s(  )", func->Name() ) );
+	}
+
+	if (stack->s == -1) //this is a fake stack created by debugger, use intruction pointer for retrieval.
+		st = &const_cast<idProgram*>( program )->GetStatement( instructionPtr );
+	else // Use the calling statement as the filename and linenumber where the call was made from
+		st = &const_cast<idProgram*>( program )->GetStatement ( stack->s );
+
+	if ( st )
+	{
+		idStr qpath = const_cast<idProgram*>( program )->GetFilename( st->file );
+		if (idStr::FindChar( qpath, ':' ) != -1)
+			qpath = fileSystem->OSPathToRelativePath( qpath.c_str() );
+		qpath.BackSlashesToSlashes ( );
+		msg->WriteString( qpath );
+		msg->WriteInt( st->linenumber );
+	}
+	else
+	{
+		msg->WriteString ( "<UNKNOWN>" );
+		msg->WriteInt ( 0 );
+	}
+}
+
+void idGameEdit::MSG_WriteInterpreterInfo(idBitMsg* msg, const idInterpreter* interpreter, const idProgram* program, int instructionPtr)
+{
+	int			i;
+	prstack_s	temp;
+
+	msg->WriteShort((int)interpreter->GetCallstackDepth( ) );
+
+	// write out the current function
+	temp.f = interpreter->GetCurrentFunction( );
+	temp.s = -1;
+	temp.stackbase = 0;
+	MSG_WriteCallstackFunc( msg, &temp, program, instructionPtr);
+
+	// Run through all of the callstack and write each to the msg
+	for (i = interpreter->GetCallstackDepth() - 1; i > 0; i--)
+	{
+		MSG_WriteCallstackFunc( msg, interpreter->GetCallstack( ) + i, program, instructionPtr);
+	}
+}
+
+
+int idGameEdit::GetInterpreterCallStackDepth(const idInterpreter* interpreter)
+{
+	return interpreter->GetCallstackDepth();
+}
+
+const function_t*idGameEdit::GetInterpreterCallStackFunction( const idInterpreter* interpreter, int stackDepth/* = -1*/)
+{
+	return interpreter->GetCallstack( )[ stackDepth > -1 ? stackDepth :interpreter->GetCallstackDepth( ) ].f;
+}

--- a/game/script/Script_Thread.cpp
+++ b/game/script/Script_Thread.cpp
@@ -2899,3 +2899,51 @@ void idThread::Event_CallFunctionsByWildcard( const char* functionNameWildcard )
 		newThread->DelayedStart( 0 );
 	}
 }
+
+// DG: all the following are for Script Debugger (ported from dhewm3)
+
+int idGameEdit::ThreadGetNum(const idThread* thread) const
+{
+	return const_cast<idThread*>(thread)->GetThreadNum();
+}
+
+const char*idGameEdit::ThreadGetName(const idThread* thread) const
+{
+	return const_cast<idThread*>(thread)->GetThreadName();
+}
+
+int	idGameEdit::GetTotalScriptThreads() const
+{
+	return idThread::GetThreads().Num();
+}
+
+const idThread*idGameEdit::GetThreadByIndex(int index) const
+{
+	return idThread::GetThreads()[index];
+}
+
+bool idGameEdit::ThreadIsDoneProcessing(const idThread* thread) const
+{
+	return const_cast<idThread*>(thread)->IsDoneProcessing();
+}
+
+bool idGameEdit::ThreadIsWaiting(const idThread* thread) const
+{
+	return const_cast<idThread*>(thread)->IsWaiting();
+}
+
+bool idGameEdit::ThreadIsDying(const idThread* thread) const
+{
+	return const_cast<idThread*>(thread)->IsDying();
+}
+
+void idGameEdit::MSG_WriteThreadInfo(idBitMsg* msg, const idThread* thread, const idInterpreter* interpreter)
+{
+	msg->WriteString(const_cast<idThread*>(thread)->GetThreadName());
+	msg->WriteInt(const_cast<idThread*>(thread)->GetThreadNum());
+
+	msg->WriteBits((int)(thread == interpreter->GetThread()), 1);
+	msg->WriteBits((int)const_cast<idThread*>(thread)->IsDoneProcessing(), 1);
+	msg->WriteBits((int)const_cast<idThread*>(thread)->IsWaiting(), 1);
+	msg->WriteBits((int)const_cast<idThread*>(thread)->IsDying(), 1);
+}

--- a/game/script/Script_Thread.cpp
+++ b/game/script/Script_Thread.cpp
@@ -974,7 +974,7 @@ idThread::IsWaiting
 Checks if thread is still waiting for some event to occur.
 ================
 */
-bool idThread::IsWaiting( void ) {
+bool idThread::IsWaiting( void ) const {
 	if ( waitingForThread || ( waitingFor != ENTITYNUM_NONE ) ) {
 		return true;
 	}
@@ -2939,11 +2939,11 @@ bool idGameEdit::ThreadIsDying(const idThread* thread) const
 
 void idGameEdit::MSG_WriteThreadInfo(idBitMsg* msg, const idThread* thread, const idInterpreter* interpreter)
 {
-	msg->WriteString(const_cast<idThread*>(thread)->GetThreadName());
-	msg->WriteInt(const_cast<idThread*>(thread)->GetThreadNum());
+	msg->WriteString(thread->GetThreadName());
+	msg->WriteInt(thread->GetThreadNum());
 
 	msg->WriteBits((int)(thread == interpreter->GetThread()), 1);
-	msg->WriteBits((int)const_cast<idThread*>(thread)->IsDoneProcessing(), 1);
-	msg->WriteBits((int)const_cast<idThread*>(thread)->IsWaiting(), 1);
-	msg->WriteBits((int)const_cast<idThread*>(thread)->IsDying(), 1);
+	msg->WriteBits((int)thread->IsDoneProcessing(), 1);
+	msg->WriteBits((int)thread->IsWaiting(), 1);
+	msg->WriteBits((int)thread->IsDying(), 1);
 }

--- a/game/script/Script_Thread.h
+++ b/game/script/Script_Thread.h
@@ -271,8 +271,8 @@ public:
 								
 	static idList<idThread*>&	GetThreads ( void );
 	
-	bool						IsDoneProcessing ( void );
-	bool						IsDying			 ( void );	
+	bool						IsDoneProcessing ( void ) const;
+	bool						IsDying			 ( void ) const;
 								
 	void						End( void );
 	static void					KillThread( const char *name );
@@ -283,7 +283,7 @@ public:
 	void						ContinueProcessing( void ) { interpreter.doneProcessing = false; };
 	bool						ThreadDying( void ) { return interpreter.threadDying; };
 	void						EndThread( void ) { interpreter.threadDying = true; };
-	bool						IsWaiting( void );
+	bool						IsWaiting( void ) const;
 	void						ClearWaitFor( void );
 	bool						IsWaitingFor( idEntity *obj );
 	void						ObjectMoveDone( idEntity *obj );
@@ -292,9 +292,9 @@ public:
 	bool						Start( void );
 	idThread					*WaitingOnThread( void );
 	void						SetThreadNum( int num );
-	int 						GetThreadNum( void );
+	int 						GetThreadNum( void ) const;
 	void						SetThreadName( const char *name );
-	const char					*GetThreadName( void );
+	const char					*GetThreadName( void ) const;
 
 	void						Error( const char *fmt, ... ) const id_attribute((format(printf,2,3)));
 
@@ -336,7 +336,7 @@ ID_INLINE void idThread::SetThreadNum( int num ) {
 idThread::GetThreadNum
 ================
 */
-ID_INLINE int idThread::GetThreadNum( void ) {
+ID_INLINE int idThread::GetThreadNum( void ) const {
 	return threadNum;
 }
 
@@ -345,7 +345,7 @@ ID_INLINE int idThread::GetThreadNum( void ) {
 idThread::GetThreadName
 ================
 */
-ID_INLINE const char *idThread::GetThreadName( void ) {
+ID_INLINE const char *idThread::GetThreadName( void ) const {
 	return threadName.c_str();
 }
 
@@ -363,7 +363,7 @@ ID_INLINE idList<idThread*>& idThread::GetThreads ( void ) {
 idThread::IsDoneProcessing
 ================
 */
-ID_INLINE bool idThread::IsDoneProcessing ( void ) {
+ID_INLINE bool idThread::IsDoneProcessing ( void ) const {
 	return interpreter.doneProcessing;
 }
 
@@ -372,7 +372,7 @@ ID_INLINE bool idThread::IsDoneProcessing ( void ) {
 idThread::IsDying
 ================
 */
-ID_INLINE bool idThread::IsDying ( void ) {
+ID_INLINE bool idThread::IsDying ( void ) const {
 	return interpreter.threadDying;
 }
 

--- a/idlib/sys/posix/posix_thread.cpp
+++ b/idlib/sys/posix/posix_thread.cpp
@@ -252,9 +252,10 @@ void Sys_DestroyThread( uintptr_t threadHandle )
 #endif
 #endif
 	
-	if( pthread_join( ( pthread_t )threadHandle, NULL ) != 0 )
+	int e = pthread_join( ( pthread_t )threadHandle, NULL );
+	if( e != 0 )
 	{
-		idLib::common->FatalError( "ERROR: pthread_join %s failed\n", name );
+		idLib::common->FatalError( "ERROR: pthread_join %s failed: %s (%d)\n", name, strerror(e), e );
 	}
 }
 

--- a/sys/posix/posix_main.cpp
+++ b/sys/posix/posix_main.cpp
@@ -427,6 +427,10 @@ ID_TIME_T Sys_FileTimeStamp(FILE * fp) {
 }
 
 void Sys_Sleep(int msec) {
+#if 0
+	// DG: the following makes no sense to me, Sys_Sleep() on Windows allows any value
+	//     and usleep() on Linux actually has a much better resolution (also in practice)
+	//     than any Windows sleep function
 	if ( msec < 20 ) {
 		static int last = 0;
 		int now = Sys_Milliseconds();
@@ -437,6 +441,7 @@ void Sys_Sleep(int msec) {
 		// ignore that sleep call, keep going
 		return;
 	}
+#endif // 0
 	// use nanosleep? keep sleeping if signal interrupt?
 	if (usleep(msec * 1000) == -1)
 		Sys_Printf("usleep: %s\n", strerror(errno));

--- a/sys/win32/rc/Debugger.rc
+++ b/sys/win32/rc/Debugger.rc
@@ -126,21 +126,21 @@ IDI_DBG_EMPTY           ICON                    "res\\dbg_empty.ico"
 
 IDR_DBG_ACCELERATORS ACCELERATORS 
 BEGIN
-    VK_F9,          ID_DBG_DEBUG_QUICKWATCH, VIRTKEY, SHIFT, NOINVERT
-    VK_F5,          ID_DBG_DEBUG_RUN,       VIRTKEY, NOINVERT
-    VK_F11,         ID_DBG_DEBUG_STEPINTO,  VIRTKEY, NOINVERT
-    VK_F10,         ID_DBG_DEBUG_STEPOVER,  VIRTKEY, NOINVERT
-    VK_F9,          ID_DBG_DEBUG_TOGGLEBREAKPOINT, VIRTKEY, NOINVERT
-    VK_F3,          ID_DBG_EDIT_FINDNEXT,   VIRTKEY, NOINVERT
-    VK_F3,          ID_DBG_EDIT_FINDPREV,   VIRTKEY, SHIFT, NOINVERT
-    VK_F3,          ID_DBG_EDIT_FINDSELECTED, VIRTKEY, CONTROL, NOINVERT
-    VK_F3,          ID_DBG_EDIT_FINDSELECTED, VIRTKEY, CONTROL, NOINVERT
-    VK_F3,          ID_DBG_EDIT_FINDSELECTEDPREV, VIRTKEY, SHIFT, CONTROL, 
-                                                    NOINVERT
-    VK_F4,          ID_DBG_FILE_CLOSE,      VIRTKEY, CONTROL, NOINVERT
-    VK_TAB,         ID_DBG_FILE_NEXT,       VIRTKEY, CONTROL, NOINVERT
-    "O",            ID_DBG_FILE_OPEN,       VIRTKEY, CONTROL, NOINVERT
-    "F",            ID_DBG_EDIT_FIND,       VIRTKEY, CONTROL, NOINVERT
+    VK_F9,          ID_DBG_DEBUG_QUICKWATCH,            VIRTKEY, SHIFT, NOINVERT
+    VK_F5,          ID_DBG_DEBUG_RUN,                   VIRTKEY, NOINVERT
+    VK_F11,         ID_DBG_DEBUG_STEPINTO,              VIRTKEY, NOINVERT
+    VK_F10,         ID_DBG_DEBUG_STEPOVER,              VIRTKEY, NOINVERT
+    VK_F9,          ID_DBG_DEBUG_TOGGLEBREAKPOINT,      VIRTKEY, NOINVERT
+    VK_F3,          ID_DBG_EDIT_FINDNEXT,               VIRTKEY, NOINVERT
+    VK_F3,          ID_DBG_EDIT_FINDPREV,               VIRTKEY, SHIFT, NOINVERT
+    VK_F3,          ID_DBG_EDIT_FINDSELECTED,           VIRTKEY, CONTROL, NOINVERT
+    VK_F3,          ID_DBG_EDIT_FINDSELECTEDPREV,       VIRTKEY, SHIFT, CONTROL,NOINVERT
+    VK_F4,          ID_DBG_FILE_CLOSE,                  VIRTKEY, CONTROL, NOINVERT
+    VK_TAB,         ID_DBG_FILE_NEXT,                   VIRTKEY, CONTROL, NOINVERT
+    VK_RETURN,      ID_DBG_SEND_COMMAND,                VIRTKEY, NOINVERT
+    "O",            ID_DBG_FILE_OPEN,                   VIRTKEY, CONTROL, NOINVERT
+    "F",            ID_DBG_EDIT_FIND,                   VIRTKEY, CONTROL, NOINVERT
+    
 END
 
 
@@ -149,17 +149,17 @@ END
 // Dialog
 //
 
-IDD_DBG_ABOUT DIALOGEX 0, 0, 222, 71
+IDD_DBG_ABOUT DIALOGEX 0, 0, 250, 90
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | 
     WS_CAPTION | WS_SYSMENU
 CAPTION "About Script Debugger"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
     LTEXT           "Script Debugger",IDC_STATIC,35,7,81,8
-    LTEXT           "Version 0.01",IDC_STATIC,35,17,41,8
-    LTEXT           "Original version by Raven",IDC_STATIC,35,
-                    28,134,8
-    DEFPUSHBUTTON   "OK",IDOK,165,50,50,14
+    LTEXT           "Version 1.1",IDC_STATIC,35,17,41,8
+    LTEXT           "Original version by Raven", IDC_STATIC, 35,28, 134, 8
+    LTEXT           "Dhewm3 version by Harrie van Ginneken \n\t\t\t\tand\n\t\t\t Daniel Gibson", IDC_STATIC, 35, 38, 134, 32
+    DEFPUSHBUTTON   "OK",IDOK,100,68,50,14
     ICON            5098,IDC_STATIC,7,7,20,20
 END
 

--- a/sys/win32/rc/Debugger.rc
+++ b/sys/win32/rc/Debugger.rc
@@ -103,6 +103,10 @@ BEGIN
         MENUITEM "&Show Next Statement",        ID_DBG_DEBUG_SHOWNEXTSTATEMENT
 
         MENUITEM "&Run To Cursor",              ID_DBG_DEBUG_RUNTOCURSOR
+        MENUITEM SEPARATOR
+        MENUITEM "&Find Selected",              ID_DBG_EDIT_FINDSELECTED
+        MENUITEM "Find &Next\tF3",              ID_DBG_EDIT_FINDNEXT
+        MENUITEM "Find &Prev\tShift+F3",        ID_DBG_EDIT_FINDPREV
     END
 END
 

--- a/sys/win32/rc/Debugger_resource.h
+++ b/sys/win32/rc/Debugger_resource.h
@@ -63,6 +63,7 @@ Project: The Dark Mod (http://www.thedarkmod.com/)
 #define ID_DBG_EDIT_FINDPREV                     22022
 #define ID_DBG_EDIT_FINDSELECTEDPREV             22023
 #define ID_DBG_HELP_ABOUT                        22024
+#define ID_DBG_SEND_COMMAND                      22025
 
 // Next default values for new objects
 // 

--- a/sys/win32/win_main.cpp
+++ b/sys/win32/win_main.cpp
@@ -1092,7 +1092,9 @@ int WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 
 	// Launch the script debugger
 	if ( strstr( lpCmdLine, "+debugger" ) ) {
-		// DebuggerClientInit( lpCmdLine );
+#ifdef ID_ALLOW_TOOLS
+		DebuggerClientInit(GetCommandLine());
+#endif
 		return 0;
 	}
 

--- a/tools/common/OpenFileDialog.cpp
+++ b/tools/common/OpenFileDialog.cpp
@@ -381,7 +381,10 @@ void rvOpenFileDialog::SetFilter ( const char* s )
 		if ( semi != -1 )
 		{
 			filter  = filters.Left ( semi );
-			filters = filters.Right ( filters.Length ( ) - semi );
+			// DG: the following change was made in dhewm3 for the script debugger
+			//filters = filters.Right ( filters.Length ( ) - semi );
+			filters = filters.Right ( filters.Length ( ) - (semi + 1));
+			filters.Strip(' ');
 		}
 		else
 		{

--- a/tools/debugger/DebuggerApp.cpp
+++ b/tools/debugger/DebuggerApp.cpp
@@ -1,0 +1,165 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "tools/edit_gui_common.h"
+
+
+#include "../../sys/win32/rc/debugger_resource.h"
+#include "DebuggerApp.h"
+
+/*
+================
+rvDebuggerApp::rvDebuggerApp
+================
+*/
+rvDebuggerApp::rvDebuggerApp ( ) //:
+	//mOptions ( "Software\\id Software\\DOOM3\\Tools\\Debugger" )
+{
+	mInstance		= NULL;
+	mDebuggerWindow = NULL;
+	mAccelerators   = NULL;
+}
+
+/*
+================
+rvDebuggerApp::~rvDebuggerApp
+================
+*/
+rvDebuggerApp::~rvDebuggerApp ( )
+{
+	if ( mAccelerators )
+	{
+		DestroyAcceleratorTable ( mAccelerators );
+	}
+}
+
+/*
+================
+rvDebuggerApp::Initialize
+
+Initializes the debugger application by creating the debugger window
+================
+*/
+bool rvDebuggerApp::Initialize ( HINSTANCE instance )
+{
+	INITCOMMONCONTROLSEX ex;
+	ex.dwICC = ICC_USEREX_CLASSES | ICC_LISTVIEW_CLASSES | ICC_WIN95_CLASSES;
+	ex.dwSize = sizeof(INITCOMMONCONTROLSEX);
+
+	mInstance = instance;
+
+	mOptions.Load ( );
+
+	mDebuggerWindow = new rvDebuggerWindow;
+
+	if ( !mDebuggerWindow->Create ( instance ) )
+	{
+		delete mDebuggerWindow;
+		return false;
+	}
+
+	// Initialize the network connection for the debugger
+	if ( !mClient.Initialize ( ) )
+	{
+		return false;
+	}
+
+	mAccelerators = LoadAccelerators ( mInstance, MAKEINTRESOURCE(IDR_DBG_ACCELERATORS) );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerApp::ProcessWindowMessages
+
+Process windows messages
+================
+*/
+bool rvDebuggerApp::ProcessWindowMessages ( void )
+{
+	MSG	msg;
+
+	while ( PeekMessage ( &msg, NULL, 0, 0, PM_NOREMOVE ) )
+	{
+		if ( !GetMessage (&msg, NULL, 0, 0) )
+		{
+			return false;
+		}
+
+		if ( !TranslateAccelerator ( &msg ) )
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	return true;
+}
+
+/*
+================
+rvDebuggerApp::TranslateAccelerator
+
+Translate any accelerators destined for this window
+================
+*/
+bool rvDebuggerApp::TranslateAccelerator ( LPMSG msg )
+{
+	if ( mDebuggerWindow && ::TranslateAccelerator ( mDebuggerWindow->GetWindow(), mAccelerators, msg ) )
+	{
+		return true;
+	}
+
+	return false;
+}
+
+/*
+================
+rvDebuggerApp::Run
+
+Main Loop for the debugger application
+================
+*/
+int rvDebuggerApp::Run ( void )
+{
+	// Main message loop:
+	while ( ProcessWindowMessages ( ) )
+	{
+		mClient.ProcessMessages ( );
+
+		Sleep ( 0 );
+	}
+
+	mClient.Shutdown ( );
+	mOptions.Save ( );
+
+	delete mDebuggerWindow;
+
+	return 1;
+}

--- a/tools/debugger/DebuggerApp.cpp
+++ b/tools/debugger/DebuggerApp.cpp
@@ -26,9 +26,6 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-#include "tools/edit_gui_common.h"
-
-
 #include "../../sys/win32/rc/debugger_resource.h"
 #include "DebuggerApp.h"
 

--- a/tools/debugger/DebuggerApp.h
+++ b/tools/debugger/DebuggerApp.h
@@ -1,0 +1,110 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERAPP_H_
+#define DEBUGGERAPP_H_
+
+#include "../../sys/win32/win_local.h"
+//#include "../../framework/sync/Msg.h"
+
+#ifndef REGISTRYOPTIONS_H_
+#include "../common/RegistryOptions.h"
+#endif
+
+#ifndef DEBUGGERWINDOW_H_
+#include "DebuggerWindow.h"
+#endif
+
+#ifndef DEBUGGERMESSAGES_H_
+#include "DebuggerMessages.h"
+#endif
+
+#ifndef DEBUGGERCLIENT_H_
+#include "DebuggerClient.h"
+#endif
+
+// These were changed to static by ID so to make it easy we just throw them
+// in this header
+// we need a lot to be able to list all threads in mars_city1
+const int MAX_MSGLEN = 8600;
+
+class rvDebuggerApp
+{
+public:
+
+	rvDebuggerApp ( );
+	~rvDebuggerApp();
+
+	bool				Initialize				( HINSTANCE hInstance );
+	int					Run						( void );
+
+	rvRegistryOptions&	GetOptions				( void );
+	rvDebuggerClient&	GetClient				( void );
+	rvDebuggerWindow&	GetWindow				( void );
+
+	HINSTANCE			GetInstance				( void );
+
+	bool				TranslateAccelerator	( LPMSG msg );
+
+protected:
+
+	rvRegistryOptions	mOptions;
+	rvDebuggerWindow*	mDebuggerWindow;
+	HINSTANCE			mInstance;
+	rvDebuggerClient	mClient;
+	HACCEL				mAccelerators;
+
+private:
+
+	bool	ProcessNetMessages		( void );
+	bool	ProcessWindowMessages	( void );
+};
+
+ID_INLINE HINSTANCE rvDebuggerApp::GetInstance ( void )
+{
+	return mInstance;
+}
+
+ID_INLINE rvDebuggerClient& rvDebuggerApp::GetClient ( void )
+{
+	return mClient;
+}
+
+ID_INLINE rvRegistryOptions& rvDebuggerApp::GetOptions ( void )
+{
+	return mOptions;
+}
+
+ID_INLINE rvDebuggerWindow& rvDebuggerApp::GetWindow ( void )
+{
+	assert ( mDebuggerWindow );
+	return *mDebuggerWindow;
+}
+
+extern rvDebuggerApp gDebuggerApp;
+
+#endif // DEBUGGERAPP_H_

--- a/tools/debugger/DebuggerBreakpoint.cpp
+++ b/tools/debugger/DebuggerBreakpoint.cpp
@@ -1,0 +1,65 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#if defined( ID_ALLOW_TOOLS )
+#include "tools/edit_gui_common.h"
+#include "DebuggerApp.h"
+#else
+#include "debugger_common.h"
+#endif
+
+#include "DebuggerBreakpoint.h"
+
+int rvDebuggerBreakpoint::mNextID = 1;
+
+rvDebuggerBreakpoint::rvDebuggerBreakpoint ( const char* filename, int linenumber, int id, bool onceOnly )
+{
+	mFilename = filename;
+	mLineNumber = linenumber;
+	mEnabled = true;
+	mOnceOnly = onceOnly;
+
+	if ( id == -1 )
+	{
+		mID = mNextID++;
+	}
+	else
+	{
+		mID = id;
+	}
+}
+
+rvDebuggerBreakpoint::rvDebuggerBreakpoint ( rvDebuggerBreakpoint& bp )
+{
+	mFilename = bp.mFilename;
+	mEnabled = bp.mEnabled;
+	mLineNumber = bp.mLineNumber;
+}
+
+rvDebuggerBreakpoint::~rvDebuggerBreakpoint ( void )
+{
+}

--- a/tools/debugger/DebuggerBreakpoint.cpp
+++ b/tools/debugger/DebuggerBreakpoint.cpp
@@ -26,7 +26,6 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 #if defined( ID_ALLOW_TOOLS )
-#include "tools/edit_gui_common.h"
 #include "DebuggerApp.h"
 #else
 #include "debugger_common.h"

--- a/tools/debugger/DebuggerBreakpoint.h
+++ b/tools/debugger/DebuggerBreakpoint.h
@@ -1,0 +1,78 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERBREAKPOINT_H_
+#define DEBUGGERBREAKPOINT_H_
+
+class idProgram;
+
+class rvDebuggerBreakpoint
+{
+public:
+
+	rvDebuggerBreakpoint ( const char* filename, int linenumber, int id = -1, bool onceOnly = false );
+	rvDebuggerBreakpoint ( rvDebuggerBreakpoint& bp );
+	~rvDebuggerBreakpoint ( void );
+
+	const char*		GetFilename		( void );
+	int				GetLineNumber	( void );
+	int				GetID			( void );
+	bool			GetOnceOnly     ( void );
+
+protected:
+
+	bool	mEnabled;
+	bool	mOnceOnly;
+	int		mID;
+	int		mLineNumber;
+	idStr	mFilename;
+private:
+
+	static int	mNextID;
+};
+
+ID_INLINE const char* rvDebuggerBreakpoint::GetFilename ( void )
+{
+	return mFilename;
+}
+
+ID_INLINE int rvDebuggerBreakpoint::GetLineNumber ( void )
+{
+	return mLineNumber;
+}
+
+ID_INLINE int rvDebuggerBreakpoint::GetID ( void )
+{
+	return mID;
+}
+
+ID_INLINE bool rvDebuggerBreakpoint::GetOnceOnly( void )
+{
+	return mOnceOnly;
+}
+
+#endif // DEBUGGERBREAKPOINT_H_

--- a/tools/debugger/DebuggerClient.cpp
+++ b/tools/debugger/DebuggerClient.cpp
@@ -1,0 +1,685 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "tools/edit_gui_common.h"
+
+
+#include "DebuggerApp.h"
+
+/*
+================
+rvDebuggerClient::rvDebuggerClient
+================
+*/
+rvDebuggerClient::rvDebuggerClient ( )
+{
+	mConnected = false;
+	mWaitFor   = DBMSG_UNKNOWN;
+}
+
+/*
+================
+rvDebuggerClient::~rvDebuggerClient
+================
+*/
+rvDebuggerClient::~rvDebuggerClient ( )
+{
+	ClearBreakpoints ( );
+	ClearCallstack ( );
+	ClearThreads ( );
+}
+
+/*
+================
+rvDebuggerClient::Initialize
+
+Initialize the debugger client
+================
+*/
+bool rvDebuggerClient::Initialize ( void )
+{
+	// Nothing else can run with the debugger
+	com_editors = EDITOR_DEBUGGER;
+
+	// Initialize the network connection
+	if ( !mPort.InitForPort ( 27981 ) )
+	{
+		return false;
+	}
+
+	// Server must be running on the local host on port 28980
+	Sys_StringToNetAdr ( com_dbgServerAdr.GetString( ), &mServerAdr, true );
+	mServerAdr.port = 27980;
+
+	// Attempt to let the server know we are here.  The server may not be running so this
+	// message will just get ignored.
+	SendMessage ( DBMSG_CONNECT );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerClient::Shutdown
+
+Shutdown the debugger client and let the debugger server
+know we are shutting down
+================
+*/
+void rvDebuggerClient::Shutdown ( void )
+{
+	if ( mConnected )
+	{
+		SendMessage ( DBMSG_DISCONNECT );
+		mConnected = false;
+	}
+}
+
+/*
+================
+rvDebuggerClient::ProcessMessages
+
+Process all incomding messages from the debugger server
+================
+*/
+bool rvDebuggerClient::ProcessMessages ( void )
+{
+	netadr_t adrFrom;
+	idBitMsg	 msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	msg.SetSize(MAX_MSGLEN);
+	msg.BeginReading();
+
+	int msgSize;
+	// Check for pending udp packets on the debugger port
+	while ( mPort.GetPacket ( adrFrom, buffer,msgSize, MAX_MSGLEN) )
+	{
+		short command;
+		msg.Init(buffer, sizeof(buffer));
+		msg.SetSize(msgSize);
+		msg.BeginReading();
+
+		// Only accept packets from the debugger server for security reasons
+		if ( !Sys_CompareNetAdrBase ( adrFrom, mServerAdr ) )
+		{
+			continue;
+		}
+		command = msg.ReadShort ( );
+
+		// Is this what we are waiting for? 
+		if ( command == mWaitFor )
+		{
+			mWaitFor = DBMSG_UNKNOWN;
+		}
+
+		switch ( command )
+		{
+			case DBMSG_CONNECT:
+				mConnected = true;
+				SendMessage ( DBMSG_CONNECTED );
+				SendBreakpoints ( );
+				break;
+
+			case DBMSG_CONNECTED:
+				mConnected = true;
+				SendBreakpoints ( );
+				break;
+
+			case DBMSG_DISCONNECT:
+				mConnected = false;
+				break;
+
+			case DBMSG_BREAK:
+				HandleBreak ( &msg );
+				break;
+
+			// Callstack being send to the client
+			case DBMSG_INSPECTCALLSTACK:
+				HandleInspectCallstack ( &msg );
+				break;
+
+			// Thread list is being sent to the client
+			case DBMSG_INSPECTTHREADS:
+				HandleInspectThreads ( &msg );
+				break;
+
+			case DBMSG_INSPECTVARIABLE:
+				HandleInspectVariable ( &msg );
+				break;
+
+			case DBMSG_REMOVEBREAKPOINT:
+				HandleRemoveBreakpoint( &msg );
+				break;
+			case DBMSG_INSPECTSCRIPTS:
+				HandleInspectScripts( &msg );
+				break;
+		}
+
+		// Give the window a chance to process the message
+		msg.SetReadCount(0);
+		msg.SetReadBit(0);
+		gDebuggerApp.GetWindow().ProcessNetMessage ( &msg );
+	}
+
+	return true;
+}
+
+void rvDebuggerClient::HandleRemoveBreakpoint(idBitMsg* msg)
+{
+	long lineNumber;
+	char filename[MAX_PATH];
+
+	// Read the breakpoint info
+
+	lineNumber = msg->ReadInt();
+	msg->ReadString(filename, MAX_PATH);
+
+	rvDebuggerBreakpoint* bp = FindBreakpoint(filename, lineNumber);
+	if(bp)
+		RemoveBreakpoint(bp->GetID());
+}
+
+/*
+================
+rvDebuggerClient::HandleBreak
+
+Handle the DBMSG_BREAK message send from the server.  This message is handled
+by caching the file and linenumber where the break occured.
+================
+*/
+void rvDebuggerClient::HandleBreak ( idBitMsg* msg )
+{
+	char filename[MAX_PATH];
+
+	mBreak = true;
+
+	// Line number
+	mBreakLineNumber = msg->ReadInt ( );
+
+	// Filename
+	msg->ReadString ( filename, MAX_PATH );
+	mBreakFilename   = filename;
+
+	//int64_t ptr64b = msg->ReadInt64();
+	//mBreakProgram = (idProgram*)ptr64b;
+
+	// Clear the variables
+	mVariables.Clear ( );
+
+	// Request the callstack and threads
+	SendMessage ( DBMSG_INSPECTCALLSTACK );
+	WaitFor ( DBMSG_INSPECTCALLSTACK, 2000 );
+
+	SendMessage ( DBMSG_INSPECTTHREADS );
+	WaitFor ( DBMSG_INSPECTTHREADS, 2000 );
+}
+
+
+/*
+================
+rvDebuggerClient::InspectScripts
+
+Instructs the client to inspect the loaded scripts
+================
+*/
+void rvDebuggerClient::InspectScripts ( void )
+{
+	idBitMsg	msg;
+	byte		buffer[MAX_MSGLEN];
+
+	msg.Init(buffer, sizeof(buffer));
+	msg.BeginWriting();
+	msg.WriteShort((short)DBMSG_INSPECTSCRIPTS);
+	SendPacket(msg.GetData(), msg.GetSize());
+}
+
+
+/*
+================
+rvDebuggerClient::InspectVariable
+
+Instructs the client to inspect the given variable at the given callstack depth.  The
+variable is inspected by sending a DBMSG_INSPECTVARIABLE message to the server which
+will in turn respond back to the client with the variable value
+================
+*/
+void rvDebuggerClient::InspectVariable ( const char* name, int callstackDepth )
+{
+	idBitMsg	msg;
+	byte		buffer[MAX_MSGLEN];
+
+	msg.Init( buffer, sizeof( buffer ) );
+	msg.BeginWriting();
+	msg.WriteShort ( (short)DBMSG_INSPECTVARIABLE );
+	msg.WriteShort ( (short)(mCallstack.Num()-callstackDepth) );
+	msg.WriteString ( name );
+
+	SendPacket ( msg.GetData(), msg.GetSize());
+}
+
+/*
+================
+rvDebuggerClient::HandleInspectScripts
+
+Handle the message DBMSG_INSPECTSCRIPTS being sent from the server.  This message
+is handled by adding the script entries to a list for later lookup.
+================
+*/
+void rvDebuggerClient::HandleInspectScripts( idBitMsg* msg )
+{	
+	int totalScripts;
+
+	mServerScripts.Clear();
+
+	// Read all of the callstack entries specfied in the message
+	for (totalScripts = msg->ReadInt(); totalScripts > 0; totalScripts--)
+	{
+		char temp[1024];
+
+		// Script Name
+		msg->ReadString(temp, 1024);
+		mServerScripts.Append(temp);
+	}
+}
+
+/*
+================
+rvDebuggerClient::HandleInspectCallstack
+
+Handle the message DBMSG_INSPECTCALLSTACK being sent from the server.  This message
+is handled by adding the callstack entries to a list for later lookup.
+================
+*/
+void rvDebuggerClient::HandleInspectCallstack ( idBitMsg* msg )
+{
+	int depth;
+
+	ClearCallstack ( );
+
+	// Read all of the callstack entries specfied in the message
+	for ( depth = (short)msg->ReadShort ( ) ; depth > 0; depth -- )
+	{
+		rvDebuggerCallstack* entry = new rvDebuggerCallstack;
+
+		char temp[1024];
+
+		// Function name
+		msg->ReadString ( temp, 1024 );
+		entry->mFunction = idStr(temp);
+
+		// Filename
+		msg->ReadString ( temp, 1024 );
+		entry->mFilename = idStr(temp);
+
+		// Line Number
+		entry->mLineNumber = msg->ReadInt ( );
+
+		// Add to list
+		mCallstack.Append ( entry );
+	}
+}
+
+/*
+================
+rvDebuggerClient::HandleInspectThreads
+
+Handle the message DBMSG_INSPECTTHREADS being sent from the server.  This message
+is handled by adding the list of threads to a list for later lookup.
+================
+*/
+void rvDebuggerClient::HandleInspectThreads ( idBitMsg* msg )
+{
+	int	count;
+
+	ClearThreads ( );
+
+	// Loop over the number of threads in the message
+	for ( count = (short)msg->ReadShort ( ) ; count > 0; count -- )
+	{
+		rvDebuggerThread* entry = new rvDebuggerThread;
+
+		char temp[1024];
+
+		// Thread name
+		msg->ReadString ( temp, 1024 );
+		entry->mName = temp;
+
+		// Thread ID
+		entry->mID = msg->ReadInt ( );
+
+		// Thread state
+		entry->mCurrent = msg->ReadBits ( 1 ) ? true : false;
+		entry->mDoneProcessing = msg->ReadBits ( 1 ) ? true : false;
+		entry->mWaiting = msg->ReadBits ( 1 ) ? true : false;
+		entry->mDying = msg->ReadBits ( 1 ) ? true : false;
+
+		// Add thread to list
+		mThreads.Append ( entry );
+	}
+}
+
+/*
+================
+rvDebuggerClient::HandleInspectVariable
+
+Handle the message DBMSG_INSPECTVARIABLE being sent from the server.  This message
+is handled by adding the inspected variable to a dictionary for later lookup
+================
+*/
+void rvDebuggerClient::HandleInspectVariable ( idBitMsg* msg )
+{
+	char	var[1024];
+	char	value[1024];
+	int		callDepth;
+
+	callDepth = (short)msg->ReadShort ( );
+	msg->ReadString ( var, 1024 );
+	msg->ReadString ( value, 1024 );
+
+	mVariables.Set ( va("%d:%s", mCallstack.Num()-callDepth, var), value );
+}
+
+/*
+================
+rvDebuggerClient::WaitFor
+
+Waits the given amount of time for the specified message to be received by the
+debugger client.
+================
+*/
+bool rvDebuggerClient::WaitFor ( EDebuggerMessage msg, int time )
+{
+	int start;
+
+	// Cant wait if not connected
+	if ( !mConnected )
+	{
+		return false;
+	}
+
+	start    = Sys_Milliseconds ( );
+	mWaitFor = msg;
+
+	while ( mWaitFor != DBMSG_UNKNOWN && Sys_Milliseconds()-start < time )
+	{
+		ProcessMessages ( );
+		Sleep ( 0 );
+	}
+
+	if ( mWaitFor != DBMSG_UNKNOWN )
+	{
+		mWaitFor = DBMSG_UNKNOWN;
+		return false;
+	}
+
+	return true;
+}
+
+/*
+================
+rvDebuggerClient::FindBreakpoint
+
+Searches for a breakpoint that maches the given filename and linenumber
+================
+*/
+rvDebuggerBreakpoint* rvDebuggerClient::FindBreakpoint ( const char* filename, int linenumber )
+{
+	int i;
+
+	for ( i = 0; i < mBreakpoints.Num(); i ++ )
+	{
+		rvDebuggerBreakpoint* bp = mBreakpoints[i];
+
+		if ( linenumber == bp->GetLineNumber ( ) && !idStr::Icmp ( bp->GetFilename ( ), filename ) )
+		{
+			return bp;
+		}
+	}
+
+	return NULL;
+}
+
+/*
+================
+rvDebuggerClient::ClearBreakpoints
+
+Removes all breakpoints from the client and server
+================
+*/
+void rvDebuggerClient::ClearBreakpoints ( void )
+{
+	int i;
+
+	for ( i = 0; i < GetBreakpointCount(); i ++ )
+	{
+		rvDebuggerBreakpoint* bp = mBreakpoints[i];
+		assert ( bp );
+
+		SendRemoveBreakpoint ( *bp );
+		delete bp;
+	}
+
+	mBreakpoints.Clear ( );
+}
+
+/*
+================
+rvDebuggerClient::AddBreakpoint
+
+Adds a breakpoint to the client and server with the give nfilename and linenumber
+================
+*/
+int rvDebuggerClient::AddBreakpoint ( const char* filename, int lineNumber, bool onceOnly )
+{
+	int index = mBreakpoints.Append ( new rvDebuggerBreakpoint ( filename, lineNumber, -1, onceOnly ) );
+
+	SendAddBreakpoint ( *mBreakpoints[index] );
+
+	return index;
+}
+
+/*
+================
+rvDebuggerClient::RemoveBreakpoint
+
+Removes the breakpoint with the given ID from the client and server
+================
+*/
+bool rvDebuggerClient::RemoveBreakpoint ( int bpID )
+{
+	int index;
+
+	for ( index = 0; index < GetBreakpointCount(); index ++ )
+	{
+		if ( mBreakpoints[index]->GetID ( ) == bpID )
+		{
+			SendRemoveBreakpoint ( *mBreakpoints[index] );
+			delete mBreakpoints[index];
+			mBreakpoints.RemoveIndex ( index );
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+================
+rvDebuggerClient::SendMessage
+
+Send a message with no data to the debugger server
+================
+*/
+void rvDebuggerClient::SendMessage ( EDebuggerMessage dbmsg )
+{
+	idBitMsg	 msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	msg.Init ( buffer, sizeof( buffer ) );
+	msg.BeginWriting ( );
+	msg.WriteShort ( (short)dbmsg );
+
+	SendPacket ( msg.GetData(), msg.GetSize() );
+}
+
+/*
+================
+rvDebuggerClient::SendBreakpoints
+
+Send all breakpoints to the debugger server
+================
+*/
+void rvDebuggerClient::SendBreakpoints ( void )
+{
+	int i;
+
+	if ( !mConnected )
+	{
+		return;
+	}
+
+	// Send all the breakpoints to the server
+	for ( i = 0; i < mBreakpoints.Num(); i ++ )
+	{
+		SendAddBreakpoint ( *mBreakpoints[i] );
+	}
+}
+
+/*
+================
+rvDebuggerClient::SendAddBreakpoint
+
+Send an individual breakpoint over to the debugger server
+================
+*/
+void rvDebuggerClient::SendAddBreakpoint ( rvDebuggerBreakpoint& bp )
+{
+	idBitMsg msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	if ( !mConnected )
+	{
+		return;
+	}
+
+	msg.Init( buffer, sizeof( buffer ) );
+	msg.BeginWriting();
+	msg.WriteShort	( (short)DBMSG_ADDBREAKPOINT );
+	msg.WriteBits	( bp.GetOnceOnly() ? 1 : 0, 1 );
+	msg.WriteInt	( (unsigned long) bp.GetLineNumber ( ) );
+	msg.WriteInt	( bp.GetID ( ) );
+	msg.WriteString ( bp.GetFilename() ); // FIXME: this implies make7bit ?!
+
+	SendPacket ( msg.GetData(), msg.GetSize() );
+}
+
+/*
+================
+rvDebuggerClient::SendRemoveBreakpoint
+
+Sends a remove breakpoint message to the debugger server
+================
+*/
+void rvDebuggerClient::SendRemoveBreakpoint ( rvDebuggerBreakpoint& bp )
+{
+	idBitMsg	 msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	if ( !mConnected )
+	{
+		return;
+	}
+
+	msg.Init		( buffer, sizeof( buffer ) );
+	msg.BeginWriting( );
+	msg.WriteShort	( (short)DBMSG_REMOVEBREAKPOINT );
+	msg.WriteInt	( bp.GetID() );
+
+	SendPacket ( msg.GetData(), msg.GetSize() );
+}
+
+/*
+================
+rvDebuggerClient::ClearCallstack
+
+Clear all callstack entries
+================
+*/
+void rvDebuggerClient::ClearCallstack ( void )
+{
+	int depth;
+
+	for ( depth = 0; depth < mCallstack.Num(); depth ++ )
+	{
+		delete mCallstack[depth];
+	}
+
+	mCallstack.Clear ( );
+}
+
+/*
+================
+rvDebuggerClient::ClearThreads
+
+Clear all thread entries
+================
+*/
+void rvDebuggerClient::ClearThreads ( void )
+{
+	int i;
+
+	for ( i = 0; i < mThreads.Num(); i ++ )
+	{
+		delete mThreads[i];
+	}
+
+	mThreads.Clear ( );
+}
+/*
+================
+rvDebuggerClient::SendCommand
+================
+*/
+void rvDebuggerClient::SendCommand( const char *cmdStr )
+{
+	idBitMsg msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	if ( !mConnected ) 	{
+		return;
+	}
+
+	msg.Init( buffer, sizeof( buffer ) );
+	msg.BeginWriting( );
+	msg.WriteShort( ( short ) DBMSG_EXECCOMMAND );
+	msg.WriteString( cmdStr ); // FIXME: this implies make7bit ?!
+
+	SendPacket( msg.GetData( ), msg.GetSize( ) );
+}
+

--- a/tools/debugger/DebuggerClient.cpp
+++ b/tools/debugger/DebuggerClient.cpp
@@ -26,9 +26,6 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-#include "tools/edit_gui_common.h"
-
-
 #include "DebuggerApp.h"
 
 /*

--- a/tools/debugger/DebuggerClient.h
+++ b/tools/debugger/DebuggerClient.h
@@ -1,0 +1,308 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERCLIENT_H_
+#define DEBUGGERCLIENT_H_
+
+#include "DebuggerBreakpoint.h"
+#include "idlib/containers/StrList.h"
+
+class rvDebuggerCallstack
+{
+public:
+
+	idStr	mFilename;
+	int		mLineNumber;
+	idStr	mFunction;
+};
+
+class rvDebuggerThread
+{
+public:
+
+	idStr	mName;
+	int		mID;
+	bool	mCurrent;
+	bool	mDying;
+	bool	mWaiting;
+	bool	mDoneProcessing;
+};
+
+
+typedef idList<rvDebuggerCallstack*>	rvDebuggerCallstackList;
+typedef idList<rvDebuggerThread*>		rvDebuggerThreadList;
+typedef idList<rvDebuggerBreakpoint*>	rvDebuggerBreakpointList;
+
+class rvDebuggerClient
+{
+public:
+
+	rvDebuggerClient ( );
+	~rvDebuggerClient ( );
+
+	bool						Initialize				( void );
+	void						Shutdown				( void );
+	bool						ProcessMessages			( void );
+	bool						WaitFor					( EDebuggerMessage msg, int time );
+
+	bool						IsConnected				( void );
+	bool						IsStopped				( void );
+
+	int							GetActiveBreakpointID	( void );
+	const char*					GetBreakFilename		( void );
+	int							GetBreakLineNumber		( void );
+	idProgram*					GetBreakProgram			( void );
+	rvDebuggerCallstackList&	GetCallstack			( void );
+	rvDebuggerThreadList&		GetThreads				( void );
+	const char*					GetVariableValue		( const char* name, int stackDepth );
+	idStrList&					GetServerScripts		( void );
+
+	void						InspectVariable			( const char* name, int callstackDepth );
+	void						InspectScripts			( void );
+	void						Break					( void );
+	void						Resume					( void );
+	void						StepInto				( void );
+	void						StepOver				( void );
+
+	void						SendCommand				( const char* cmdStr );
+
+	// Breakpoints
+	int							AddBreakpoint			( const char* filename, int lineNumber, bool onceOnly = false);
+	bool						RemoveBreakpoint		( int bpID );
+	void						ClearBreakpoints		( void );
+	int							GetBreakpointCount		( void );
+	rvDebuggerBreakpoint*		GetBreakpoint			( int index );
+	rvDebuggerBreakpoint*		FindBreakpoint			( const char* filename, int linenumber );
+
+protected:
+
+	void						SendMessage				( EDebuggerMessage dbmsg );
+	void						SendBreakpoints			( void );
+	void						SendAddBreakpoint		( rvDebuggerBreakpoint& bp );
+	void						SendRemoveBreakpoint	( rvDebuggerBreakpoint& bp );
+	void						SendPacket				( void* data, int datasize );
+
+	bool						mConnected;
+	netadr_t					mServerAdr;
+	idPort						mPort;
+
+	bool						mBreak;
+	int							mBreakID;
+	int							mBreakLineNumber;
+	idStr						mBreakFilename;
+
+	idDict						mVariables;
+
+	rvDebuggerCallstackList		mCallstack;
+	rvDebuggerThreadList		mThreads;
+	rvDebuggerBreakpointList	mBreakpoints;
+
+	EDebuggerMessage			mWaitFor;
+
+	idStrList					mServerScripts;
+
+private:
+
+	void		ClearCallstack				( void );
+	void		ClearThreads				( void );
+
+	void		UpdateWatches				( void );
+
+	// Network message handlers
+	void		HandleBreak					( idBitMsg* msg );
+	void		HandleInspectScripts		( idBitMsg* msg );
+	void		HandleInspectCallstack		( idBitMsg* msg );
+	void		HandleInspectThreads		( idBitMsg* msg );
+	void		HandleInspectVariable		( idBitMsg* msg );
+	void		HandleGameDLLHandle			( idBitMsg* msg );
+	void		HandleRemoveBreakpoint		( idBitMsg* msg );
+};
+
+/*
+================
+rvDebuggerClient::IsConnected
+================
+*/
+ID_INLINE bool rvDebuggerClient::IsConnected ( void )
+{
+	return mConnected;
+}
+
+/*
+================
+rvDebuggerClient::IsStopped
+================
+*/
+ID_INLINE bool rvDebuggerClient::IsStopped ( void )
+{
+	return mBreak;
+}
+
+/*
+================
+rvDebuggerClient::GetActiveBreakpointID
+================
+*/
+ID_INLINE int rvDebuggerClient::GetActiveBreakpointID ( void )
+{
+	return mBreakID;
+}
+
+/*
+================
+rvDebuggerClient::GetBreakFilename
+================
+*/
+ID_INLINE const char* rvDebuggerClient::GetBreakFilename ( void )
+{
+	return mBreakFilename;
+}
+
+/*
+================
+rvDebuggerClient::GetBreakLineNumber
+================
+*/
+ID_INLINE int rvDebuggerClient::GetBreakLineNumber ( void )
+{
+	return mBreakLineNumber;
+}
+
+/*
+================
+rvDebuggerClient::GetCallstack
+================
+*/
+ID_INLINE rvDebuggerCallstackList& rvDebuggerClient::GetCallstack ( void )
+{
+	return mCallstack;
+}
+
+/*
+================
+rvDebuggerClient::GetThreads
+================
+*/
+ID_INLINE rvDebuggerThreadList& rvDebuggerClient::GetThreads ( void )
+{
+	return mThreads;
+}
+
+/*
+================
+rvDebuggerClient::GetVariableValue
+================
+*/
+ID_INLINE const char* rvDebuggerClient::GetVariableValue ( const char* var, int stackDepth )
+{
+	return mVariables.GetString ( va("%d:%s",stackDepth,var), "" );
+}
+
+/*
+================
+rvDebuggerClient::GetBreakpointCount
+================
+*/
+ID_INLINE int rvDebuggerClient::GetBreakpointCount ( void )
+{
+	return mBreakpoints.Num ( );
+}
+
+/*
+================
+rvDebuggerClient::GetBreakpoint
+================
+*/
+ID_INLINE rvDebuggerBreakpoint* rvDebuggerClient::GetBreakpoint ( int index )
+{
+	return mBreakpoints[index];
+}
+
+/*
+================
+rvDebuggerClient::Break
+================
+*/
+ID_INLINE void rvDebuggerClient::Break ( void )
+{
+	SendMessage ( DBMSG_BREAK );
+}
+
+/*
+================
+rvDebuggerClient::Resume
+================
+*/
+ID_INLINE void rvDebuggerClient::Resume ( void )
+{
+	mBreak = false;
+	SendMessage ( DBMSG_RESUME );
+}
+
+/*
+================
+rvDebuggerClient::StepOver
+================
+*/
+ID_INLINE void rvDebuggerClient::StepOver ( void )
+{
+	mBreak = false;
+	SendMessage ( DBMSG_STEPOVER );
+}
+
+/*
+================
+rvDebuggerClient::StepInto
+================
+*/
+ID_INLINE void rvDebuggerClient::StepInto ( void )
+{
+	mBreak = false;
+	SendMessage ( DBMSG_STEPINTO );
+}
+
+/*
+================
+rvDebuggerClient::SendPacket
+================
+*/
+ID_INLINE void rvDebuggerClient::SendPacket ( void* data, int size )
+{
+	mPort.SendPacket ( mServerAdr, data, size );
+}
+
+
+/*
+================
+rvDebuggerClient::GetServerScripts
+================
+*/
+ID_INLINE idStrList& rvDebuggerClient::GetServerScripts( void )
+{
+	return mServerScripts;
+}
+#endif // DEBUGGERCLIENT_H_

--- a/tools/debugger/DebuggerFindDlg.cpp
+++ b/tools/debugger/DebuggerFindDlg.cpp
@@ -1,0 +1,107 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "tools/edit_gui_common.h"
+
+
+#include "../../sys/win32/rc/debugger_resource.h"
+#include "DebuggerApp.h"
+#include "DebuggerFindDlg.h"
+
+char rvDebuggerFindDlg::mFindText[ 256 ];
+
+/*
+================
+rvDebuggerFindDlg::rvDebuggerFindDlg
+================
+*/
+rvDebuggerFindDlg::rvDebuggerFindDlg ( void )
+{
+}
+
+/*
+================
+rvDebuggerFindDlg::DoModal
+
+Launch the dialog
+================
+*/
+bool rvDebuggerFindDlg::DoModal ( rvDebuggerWindow* parent )
+{
+	if ( DialogBoxParam ( parent->GetInstance(), MAKEINTRESOURCE(IDD_DBG_FIND), parent->GetWindow(), DlgProc, (LPARAM)this ) )
+	{
+		return true;
+	}
+
+	return false;
+}
+
+/*
+================
+rvrvDebuggerFindDlg::DlgProc
+
+Dialog Procedure for the find dialog
+================
+*/
+INT_PTR CALLBACK rvDebuggerFindDlg::DlgProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+	rvDebuggerFindDlg* dlg = (rvDebuggerFindDlg*) GetWindowLongPtr ( wnd, GWLP_USERDATA);
+
+	switch ( msg )
+	{
+		case WM_CLOSE:
+			EndDialog ( wnd, 0 );
+			break;
+
+		case WM_INITDIALOG:
+			dlg = (rvDebuggerFindDlg*) lparam;
+
+			SetWindowLongPtr ( wnd, GWLP_USERDATA, (LONG_PTR) dlg );
+			dlg->mWnd = wnd;
+			SetWindowText ( GetDlgItem ( dlg->mWnd, IDC_DBG_FIND ), dlg->mFindText );
+			return TRUE;
+
+		case WM_COMMAND:
+			switch ( LOWORD(wparam) )
+			{
+				case IDOK:
+				{
+					GetWindowText ( GetDlgItem ( wnd, IDC_DBG_FIND ), dlg->mFindText, sizeof( dlg->mFindText ) - 1 );
+					EndDialog ( wnd, 1 );
+					break;
+				}
+
+				case IDCANCEL:
+					EndDialog ( wnd, 0 );
+					break;
+			}
+			break;
+	}
+
+	return FALSE;
+}

--- a/tools/debugger/DebuggerFindDlg.cpp
+++ b/tools/debugger/DebuggerFindDlg.cpp
@@ -26,9 +26,6 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-#include "tools/edit_gui_common.h"
-
-
 #include "../../sys/win32/rc/debugger_resource.h"
 #include "DebuggerApp.h"
 #include "DebuggerFindDlg.h"

--- a/tools/debugger/DebuggerFindDlg.h
+++ b/tools/debugger/DebuggerFindDlg.h
@@ -1,0 +1,59 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERFINDDLG_H_
+#define DEBUGGERFINDDLG_H_
+
+class rvDebuggerWindow;
+
+class rvDebuggerFindDlg
+{
+public:
+
+	rvDebuggerFindDlg ( );
+
+	bool	DoModal				( rvDebuggerWindow* window );
+
+	const char*		GetFindText	( void );
+
+protected:
+
+	HWND	mWnd;
+
+private:
+
+	static char		mFindText[ 256 ];
+
+	static INT_PTR	CALLBACK DlgProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam );
+};
+
+ID_INLINE const char* rvDebuggerFindDlg::GetFindText ( void )
+{
+	return mFindText;
+}
+
+#endif // DEBUGGERFINDDLG_H_

--- a/tools/debugger/DebuggerMessages.h
+++ b/tools/debugger/DebuggerMessages.h
@@ -1,0 +1,53 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERMESSAGES_H_
+#define DEBUGGERMESSAGES_H_
+
+enum EDebuggerMessage
+{
+	DBMSG_UNKNOWN,
+	DBMSG_CONNECT,
+	DBMSG_CONNECTED,
+	DBMSG_DISCONNECT,
+	DBMSG_ADDBREAKPOINT,
+	DBMSG_REMOVEBREAKPOINT,
+	DBMSG_HITBREAKPOINT,
+	DBMSG_RESUME,
+	DBMSG_RESUMED,
+	DBMSG_BREAK,
+	DBMSG_PRINT,
+	DBMSG_INSPECTVARIABLE,
+	DBMSG_INSPECTCALLSTACK,
+	DBMSG_INSPECTTHREADS,
+	DBMSG_STEPOVER,
+	DBMSG_STEPINTO,
+	DBMSG_INSPECTSCRIPTS,
+	DBMSG_EXECCOMMAND
+};
+
+#endif // DEBUGGER_MESSAGES_H_

--- a/tools/debugger/DebuggerQuickWatchDlg.cpp
+++ b/tools/debugger/DebuggerQuickWatchDlg.cpp
@@ -1,0 +1,267 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "tools/edit_gui_common.h"
+
+
+#include "../../sys/win32/rc/debugger_resource.h"
+#include "DebuggerApp.h"
+#include "DebuggerQuickWatchDlg.h"
+
+/*
+================
+rvDebuggerQuickWatchDlg::rvDebuggerQuickWatchDlg
+================
+*/
+rvDebuggerQuickWatchDlg::rvDebuggerQuickWatchDlg ( void )
+{
+}
+
+/*
+================
+rvDebuggerQuickWatchDlg::DoModal
+
+Launch the dialog
+================
+*/
+bool rvDebuggerQuickWatchDlg::DoModal ( rvDebuggerWindow* window, int callstackDepth, const char* variable )
+{
+	mCallstackDepth = callstackDepth;
+	mDebuggerWindow = window;
+	mVariable       = variable?variable:"";
+
+	DialogBoxParam ( window->GetInstance(), MAKEINTRESOURCE(IDD_DBG_QUICKWATCH), window->GetWindow(), DlgProc, (LPARAM)this );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerQuickWatchDlg::DlgProc
+
+Dialog Procedure for the quick watch dialog
+================
+*/
+INT_PTR CALLBACK rvDebuggerQuickWatchDlg::DlgProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+	rvDebuggerQuickWatchDlg* dlg = (rvDebuggerQuickWatchDlg*) GetWindowLongPtr ( wnd, GWLP_USERDATA);
+
+	switch ( msg )
+	{
+		case WM_GETMINMAXINFO:
+		{
+			MINMAXINFO* mmi = (MINMAXINFO*)lparam;
+			mmi->ptMinTrackSize.x = 300;
+			mmi->ptMinTrackSize.y = 200;
+			break;
+		}
+
+		case WM_CLOSE:
+			gDebuggerApp.GetOptions().SetWindowPlacement ( "wp_quickwatch", wnd );
+			gDebuggerApp.GetOptions().SetColumnWidths ( "cw_quickwatch", GetDlgItem ( wnd, IDC_DBG_CURVALUE ) );
+			EndDialog ( wnd, 0 );
+			break;
+
+		case WM_SIZE:
+		{
+			RECT client;
+			RECT button;
+
+			GetClientRect ( wnd, &client );
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_RECALC ), &button );
+			ScreenToClient ( wnd, (POINT*)&button );
+			ScreenToClient ( wnd, (POINT*)&button.right );
+			MoveWindow ( GetDlgItem ( wnd, IDC_DBG_RECALC ), client.right - dlg->mButtonFromRight, button.top, button.right-button.left,button.bottom-button.top, TRUE );
+
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_CLOSE ), &button );
+			ScreenToClient ( wnd, (POINT*)&button );
+			ScreenToClient ( wnd, (POINT*)&button.right );
+			MoveWindow ( GetDlgItem ( wnd, IDC_DBG_CLOSE ), client.right - dlg->mButtonFromRight, button.top, button.right-button.left,button.bottom-button.top, TRUE );
+
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_ADDWATCH ), &button );
+			ScreenToClient ( wnd, (POINT*)&button );
+			ScreenToClient ( wnd, (POINT*)&button.right );
+			MoveWindow ( GetDlgItem ( wnd, IDC_DBG_ADDWATCH ), client.right - dlg->mButtonFromRight, button.top, button.right-button.left,button.bottom-button.top, TRUE );
+
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_VARIABLE ), &button );
+			ScreenToClient ( wnd, (POINT*)&button );
+			ScreenToClient ( wnd, (POINT*)&button.right );
+			MoveWindow ( GetDlgItem ( wnd, IDC_DBG_VARIABLE ), button.left, button.top, client.right-button.left-dlg->mEditFromRight, button.bottom-button.top, TRUE );
+
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_CURVALUE ), &button );
+			ScreenToClient ( wnd, (POINT*)&button );
+			ScreenToClient ( wnd, (POINT*)&button.right );
+			MoveWindow ( GetDlgItem ( wnd, IDC_DBG_CURVALUE ), button.left, button.top, client.right-button.left-dlg->mEditFromRight, client.bottom-button.top - dlg->mEditFromBottom, TRUE );
+
+			break;
+		}
+
+		case WM_INITDIALOG:
+		{
+			RECT  client;
+			RECT  button;
+
+			// Attach the dialog class pointer to the window
+			dlg = (rvDebuggerQuickWatchDlg*) lparam;
+			SetWindowLongPtr ( wnd, GWLP_USERDATA, lparam );
+			dlg->mWnd = wnd;
+
+			GetClientRect ( wnd, &client );
+
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_RECALC ), &button );
+			ScreenToClient ( wnd, (POINT*)&button );
+			dlg->mButtonFromRight = client.right - button.left;
+
+			GetWindowRect ( GetDlgItem ( wnd, IDC_DBG_CURVALUE ), &button );
+			ScreenToClient ( wnd, (POINT*)&button.right );
+			dlg->mEditFromRight = client.right - button.right;
+			dlg->mEditFromBottom = client.bottom - button.bottom;
+
+			// Disable the value controls until a variable is entered
+			EnableWindow ( GetDlgItem ( wnd, IDC_DBG_ADDWATCH ), false );
+			EnableWindow ( GetDlgItem ( wnd, IDC_DBG_RECALC ), false );
+			EnableWindow ( GetDlgItem ( wnd, IDC_DBG_CURVALUE ), false );
+			EnableWindow ( GetDlgItem ( wnd, IDC_DBG_CURVALUE_STATIC ), false );
+
+			// Add the columns to the list control
+			LVCOLUMN col;
+			col.mask = LVCF_WIDTH|LVCF_TEXT;
+			col.cx = 100;
+			col.pszText = "Name";
+			ListView_InsertColumn ( GetDlgItem ( wnd, IDC_DBG_CURVALUE ), 0, &col );
+			col.cx = 150;
+			col.pszText = "Value";
+			ListView_InsertColumn ( GetDlgItem ( wnd, IDC_DBG_CURVALUE ), 1, &col );
+
+			// Set the initial variable if one was given
+			if ( dlg->mVariable.Length() )
+			{
+				dlg->SetVariable ( dlg->mVariable, true );
+				SetWindowText( GetDlgItem ( wnd, IDC_DBG_VARIABLE ), dlg->mVariable );
+			}
+
+			gDebuggerApp.GetOptions().GetWindowPlacement ( "wp_quickwatch", wnd );
+			gDebuggerApp.GetOptions().GetColumnWidths ( "cw_quickwatch", GetDlgItem ( wnd, IDC_DBG_CURVALUE ) );
+
+			return TRUE;
+		}
+
+		case WM_COMMAND:
+			switch ( LOWORD(wparam) )
+			{
+				case IDC_DBG_CLOSE:
+					SendMessage ( wnd, WM_CLOSE, 0, 0 );
+					break;
+
+				case IDC_DBG_VARIABLE:
+					// When the variable text changes to something other than empty
+					// we can enable the addwatch and recalc buttons
+					if ( HIWORD(wparam) == EN_CHANGE )
+					{
+						bool enable = GetWindowTextLength ( GetDlgItem ( wnd, IDC_DBG_VARIABLE ) )?true:false;
+						EnableWindow ( GetDlgItem ( wnd, IDC_DBG_ADDWATCH ), enable );
+						EnableWindow ( GetDlgItem ( wnd, IDC_DBG_RECALC ), enable );
+					}
+					break;
+
+				case IDC_DBG_ADDWATCH:
+				{
+					char varname[1024];
+					GetWindowText ( GetDlgItem ( wnd, IDC_DBG_VARIABLE ), varname, 1023 );
+					dlg->mDebuggerWindow->AddWatch ( varname );
+					break;
+				}
+
+				case IDC_DBG_RECALC:
+				{
+					char varname[1024];
+					GetWindowText ( GetDlgItem ( wnd, IDC_DBG_VARIABLE ), varname, 1023 );
+					dlg->SetVariable ( varname );
+					break;
+				}
+			}
+			break;
+	}
+
+	return FALSE;
+}
+
+/*
+================
+rvDebuggerQuickWatchDlg::SetVariable
+
+Sets the current variable being inspected
+================
+*/
+void rvDebuggerQuickWatchDlg::SetVariable ( const char* varname, bool force )
+{
+	// See if the variable has changed
+	if ( !force && !mVariable.Icmp ( varname ) )
+	{
+		return;
+	}
+
+	// Throw up a wait cursor
+	SetCursor ( LoadCursor ( NULL, IDC_WAIT ) );
+
+	// Clear the current value list control
+	ListView_DeleteAllItems ( GetDlgItem ( mWnd, IDC_DBG_CURVALUE ) );
+
+	// Get the value of the new variable
+	gDebuggerApp.GetClient().InspectVariable ( varname, mCallstackDepth );
+
+	// Wait for the variable value to be sent over from the debugger server
+	if ( !gDebuggerApp.GetClient().WaitFor ( DBMSG_INSPECTVARIABLE, 2500 ) )
+	{
+		return;
+	}
+
+	// Make sure we got the value of the variable
+	if ( !gDebuggerApp.GetClient().GetVariableValue(varname, mCallstackDepth)[0] )
+	{
+		return;
+	}
+
+	// Enable the windows that display the current value
+	mVariable = varname;
+	EnableWindow ( GetDlgItem ( mWnd, IDC_DBG_CURVALUE ), true );
+	EnableWindow ( GetDlgItem ( mWnd, IDC_DBG_CURVALUE_STATIC ), true );
+
+	// Add the variablae value to the list control
+	LVITEM item;
+	item.mask = LVIF_TEXT;
+	item.pszText = (LPSTR)varname;
+	item.iItem = 0;
+	item.iSubItem = 0;
+	ListView_InsertItem ( GetDlgItem ( mWnd, IDC_DBG_CURVALUE ), &item );
+	ListView_SetItemText ( GetDlgItem ( mWnd, IDC_DBG_CURVALUE ), 0, 1, (LPSTR)gDebuggerApp.GetClient().GetVariableValue(varname,mCallstackDepth) );
+
+	// Give focus back to the variable edit control and set the cursor back to an arrow
+	SetFocus ( GetDlgItem ( mWnd, IDC_DBG_VARIABLE ) );
+	SetCursor ( LoadCursor ( NULL, IDC_ARROW ) );
+}

--- a/tools/debugger/DebuggerQuickWatchDlg.cpp
+++ b/tools/debugger/DebuggerQuickWatchDlg.cpp
@@ -26,9 +26,6 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-#include "tools/edit_gui_common.h"
-
-
 #include "../../sys/win32/rc/debugger_resource.h"
 #include "DebuggerApp.h"
 #include "DebuggerQuickWatchDlg.h"

--- a/tools/debugger/DebuggerQuickWatchDlg.h
+++ b/tools/debugger/DebuggerQuickWatchDlg.h
@@ -1,0 +1,59 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERQUICKWATCHDLG_H_
+#define DEBUGGERQUICKWATCHDLG_H_
+
+class rvDebuggerWindow;
+
+class rvDebuggerQuickWatchDlg
+{
+public:
+
+	rvDebuggerQuickWatchDlg ( );
+
+	bool	DoModal				( rvDebuggerWindow* window, int callstackDepth, const char* variable = NULL );
+
+protected:
+
+	HWND				mWnd;
+	int					mCallstackDepth;
+	idStr				mVariable;
+	rvDebuggerWindow*	mDebuggerWindow;
+
+	void				SetVariable	( const char* varname, bool force = false );
+
+private:
+
+	int					mEditFromRight;
+	int					mButtonFromRight;
+	int					mEditFromBottom;
+
+	static INT_PTR	CALLBACK DlgProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam );
+};
+
+#endif // DEBUGGERQUICKWATCHDLG_H_

--- a/tools/debugger/DebuggerScript.cpp
+++ b/tools/debugger/DebuggerScript.cpp
@@ -1,0 +1,177 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#if defined( ID_ALLOW_TOOLS )
+#include "tools/edit_gui_common.h"
+#include "DebuggerApp.h"
+#else
+#include "debugger_common.h"
+#endif
+
+#include "DebuggerScript.h"
+#include "../../ui/Window.h"
+#include "../../ui/UserInterfaceLocal.h"
+
+/*
+================
+rvDebuggerScript::rvDebuggerScript
+================
+*/
+rvDebuggerScript::rvDebuggerScript ( void )
+{
+	mContents  = NULL;
+	mProgram   = NULL;
+	mInterface = NULL;
+}
+
+/*
+================
+rvDebuggerScript::~rvDebuggerScript
+================
+*/
+rvDebuggerScript::~rvDebuggerScript ( void )
+{
+	Unload ( );
+}
+
+
+/*
+================
+rvDebuggerScript::Unload
+
+Unload the script from memory
+================
+*/
+void rvDebuggerScript::Unload ( void )
+{
+	delete[] mContents;
+
+	if ( mInterface )
+	{
+		delete mInterface;
+	}
+
+	mContents  = NULL;
+	mProgram   = NULL;
+	mInterface = NULL;
+}
+
+/*
+================
+rvDebuggerScript::Load
+
+Loads the debugger script and attempts to compile it using the method
+appropriate for the file being loaded.  If the script cant be compiled
+the loading of the script fails
+================
+*/
+bool rvDebuggerScript::Load ( const char* filename )
+{
+	void* buffer;
+	int	  size;
+
+	// Unload the script before reloading it
+	Unload ( );
+
+	// Cache the filename used to load the script
+	mFilename = filename;
+
+	// Read in the file
+	size = fileSystem->ReadFile ( filename, &buffer, &mModifiedTime );
+	if ( buffer == NULL )
+	{
+		return false;
+	}
+
+	// Copy the buffer over
+	mContents = new char [ size + 1 ];
+	memcpy ( mContents, buffer, size );
+	mContents[size] = 0;
+
+	// Cleanup
+	fileSystem->FreeFile ( buffer );
+	
+	return true;
+}
+
+/*
+================
+rvDebuggerScript::Reload
+
+Reload the contents of the script
+================
+*/
+bool rvDebuggerScript::Reload ( void )
+{
+	return Load ( mFilename );
+}
+
+/*
+================
+rvDebuggerScript::IsValidLine
+
+Determines whether or not the given line number within the script is a valid line of code
+================
+*/
+bool rvDebuggerScript::IsLineCode ( int linenumber )
+{
+	//we let server decide.
+	return true;
+}
+
+/*
+================
+rvDebuggerScript::IsFileModified
+
+Determines whether or not the file loaded for this script has been modified since
+it was loaded.
+================
+*/
+bool rvDebuggerScript::IsFileModified ( bool updateTime )
+{
+	ID_TIME_T	t;
+	bool	result = false;
+
+	// Grab the filetime and shut the file down
+	fileSystem->ReadFile ( mFilename, NULL, &t );
+
+	// Has the file been modified?
+	if ( t > mModifiedTime )
+	{
+		result = true;
+	}
+
+	// If updateTime is true then we will update the modified time
+	// stored in the script with the files current modified time
+	if ( updateTime )
+	{
+		mModifiedTime = t;
+	}
+
+	return result;
+}

--- a/tools/debugger/DebuggerScript.cpp
+++ b/tools/debugger/DebuggerScript.cpp
@@ -27,7 +27,6 @@ If you have questions concerning this license or the applicable additional terms
 */
 
 #if defined( ID_ALLOW_TOOLS )
-#include "tools/edit_gui_common.h"
 #include "DebuggerApp.h"
 #else
 #include "debugger_common.h"

--- a/tools/debugger/DebuggerScript.h
+++ b/tools/debugger/DebuggerScript.h
@@ -1,0 +1,80 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERSCRIPT_H_
+#define DEBUGGERSCRIPT_H_
+
+class idProgram;
+class idUserInterfaceLocal;
+
+class rvDebuggerScript
+{
+public:
+
+	rvDebuggerScript ( void );
+	~rvDebuggerScript ( void );
+
+	bool	Load		( const char* filename );
+	bool	Reload		( void );
+
+	const char*		GetFilename		( void );
+	const char*		GetContents		( void );
+	idProgram*		GetProgram		( void );
+#if 0// Test code
+	idProgram&		GetProgram		( void );
+#endif
+
+	bool			IsLineCode		( int linenumber );
+	bool			IsFileModified	( bool updateTime = false );
+
+protected:
+	void			Unload			( void );
+
+	idProgram*				mProgram;
+	idUserInterfaceLocal*	mInterface;
+	char*					mContents;
+	idStr					mFilename;
+	ID_TIME_T				mModifiedTime;
+};
+
+ID_INLINE const char* rvDebuggerScript::GetFilename	( void )
+{
+	return mFilename;
+}
+
+ID_INLINE const char* rvDebuggerScript::GetContents	( void )
+{
+	return mContents?mContents:"";
+}
+
+ID_INLINE idProgram* rvDebuggerScript::GetProgram ( void )
+{
+	return mProgram;
+}
+
+
+#endif // DEBUGGERSCRIPT_H_

--- a/tools/debugger/DebuggerServer.cpp
+++ b/tools/debugger/DebuggerServer.cpp
@@ -1,0 +1,798 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+Copyright (C) 1999-2011 Raven Software
+Copyright (C) 2021 Harrie van Ginneken
+Copyright (C) 2021-2026 Daniel Gibson
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+
+
+#if defined( ID_ALLOW_TOOLS )
+#include "tools/edit_gui_common.h"
+#include "DebuggerServer.h"
+#include "DebuggerApp.h"
+#else
+#include "DebuggerServer.h"
+#include "debugger_common.h"
+// we need a lot to be able to list all threads in mars_city1
+const int MAX_MSGLEN = 8600;
+#endif
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+  // compat with SDL2
+  #define SDL_CreateCond SDL_CreateCondition
+  #define SDL_DestroyCond SDL_DestroyCondition
+  #define SDL_CondWait SDL_WaitCondition
+  #define SDL_CondSignal SDL_SignalCondition
+#endif
+
+/*
+================
+rvDebuggerServer::rvDebuggerServer
+================
+*/
+rvDebuggerServer::rvDebuggerServer ( )
+{
+	mConnected			= false;
+	mBreakNext			= false;
+	mBreak				= false;
+	mBreakStepOver		= false;
+	mBreakStepInto		= false;
+	mGameThreadBreakCond = NULL;
+	mGameThreadBreakLock = NULL;
+	mLastStatementLine	= -1;
+	mBreakStepOverFunc1 = NULL;
+	mBreakStepOverFunc2 = NULL;
+	mBreakInstructionPointer = 0;
+	mBreakInterpreter = NULL;
+	mBreakProgram = NULL;
+	mGameDLLHandle = 0;
+	mBreakStepOverDepth = 0;
+	mCriticalSection = NULL;
+}
+
+/*
+================
+rvDebuggerServer::~rvDebuggerServer
+================
+*/
+rvDebuggerServer::~rvDebuggerServer ( )
+{
+}
+
+/*
+================
+rvDebuggerServer::Initialize
+
+Initialize the debugger server.  This function should be called before the
+debugger server is used.
+================
+*/
+bool rvDebuggerServer::Initialize ( void )
+{
+	// Initialize the network connection
+	if ( !mPort.InitForPort ( 27980 ) )
+	{
+		return false;
+	}
+
+	// we're using a condition variable to pause the game thread in rbDebuggerServer::Break()
+	// until rvDebuggerServer::Resume() is called (from another thread)
+	mGameThreadBreakCond = SDL_CreateCond();
+	mGameThreadBreakLock = SDL_CreateMutex();
+
+	// Create a critical section to ensure that the shared thread
+	// variables are protected
+	mCriticalSection = SDL_CreateMutex();
+
+	// Server must be running on the local host on port 28980
+	Sys_StringToNetAdr ( com_dbgClientAdr.GetString( ), &mClientAdr, true );
+	mClientAdr.port = 27981;
+
+	// Attempt to let the server know we are here.  The server may not be running so this
+	// message will just get ignored.
+	SendMessage ( DBMSG_CONNECT );
+
+	return true;
+}
+
+void rvDebuggerServer::OSPathToRelativePath( const char *osPath, idStr &qpath )
+{
+	if ( strchr( osPath, ':' ) ) // XXX: what about linux?
+	{
+		qpath = fileSystem->OSPathToRelativePath( osPath );
+	}
+	else
+	{
+		qpath = osPath;
+	}
+}
+
+/*
+================
+rvDebuggerServer::Shutdown
+
+Shutdown the debugger server.
+================
+*/
+void rvDebuggerServer::Shutdown ( void )
+{
+	// Let the debugger client know we are shutting down
+	if ( mConnected )
+	{
+		SendMessage ( DBMSG_DISCONNECT );
+		mConnected = false;
+	}
+
+	mPort.Close();
+
+	Resume(); // just in case we're still paused
+
+	// dont need the crit section anymore
+	SDL_DestroyMutex( mCriticalSection );
+	mCriticalSection = NULL;
+
+	SDL_DestroyCond( mGameThreadBreakCond );
+	mGameThreadBreakCond = NULL;
+	SDL_DestroyMutex( mGameThreadBreakLock );
+	mGameThreadBreakLock = NULL;
+}
+
+/*
+================
+rvDebuggerServer::ProcessMessages
+
+Process all incoming network messages from the debugger client
+================
+*/
+bool rvDebuggerServer::ProcessMessages ( void )
+{
+	netadr_t adrFrom;
+	idBitMsg	 msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	// Check for pending udp packets on the debugger port
+	int msgSize;
+	while ( mPort.GetPacket ( adrFrom, buffer, msgSize, MAX_MSGLEN) )
+	{
+		short command;
+		msg.Init(buffer, sizeof(buffer));
+		msg.SetSize(msgSize);
+		msg.BeginReading();
+		
+		if ( adrFrom.type != NA_LOOPBACK ) {
+			// Only accept packets from the debugger server for security reasons
+			if ( !Sys_CompareNetAdrBase( adrFrom, mClientAdr ) )
+				continue;
+		}
+
+		command = msg.ReadShort( );
+
+		switch ( command )
+		{
+			case DBMSG_CONNECT:
+				mConnected = true;
+				SendMessage ( DBMSG_CONNECTED );
+				HandleInspectScripts ( NULL );
+				com_editors |= EDITOR_DEBUGGER;
+				break;
+
+			case DBMSG_CONNECTED:
+				mConnected = true;
+				HandleInspectScripts( NULL );
+				com_editors |= EDITOR_DEBUGGER;
+				break;
+
+			case DBMSG_DISCONNECT:
+				ClearBreakpoints ( );
+				Resume ( );
+				mConnected = false;
+				com_editors &= ~EDITOR_DEBUGGER;
+				break;
+
+			case DBMSG_ADDBREAKPOINT:
+				HandleAddBreakpoint ( &msg );
+				break;
+
+			case DBMSG_REMOVEBREAKPOINT:
+				HandleRemoveBreakpoint ( &msg );
+				break;
+
+			case DBMSG_RESUME:
+				HandleResume ( &msg );
+				break;
+
+			case DBMSG_BREAK:
+				mBreakNext = true;
+				break;
+
+			case DBMSG_STEPOVER:
+				mBreakStepOver = true;
+				mBreakStepOverDepth = gameEdit->GetInterpreterCallStackDepth(mBreakInterpreter);
+				mBreakStepOverFunc1 = gameEdit->GetInterpreterCallStackFunction(mBreakInterpreter);
+				if (mBreakStepOverDepth)
+				{
+					mBreakStepOverFunc2 = gameEdit->GetInterpreterCallStackFunction(mBreakInterpreter,mBreakStepOverDepth - 1);
+				}
+				else
+				{
+					mBreakStepOverFunc2 = NULL;
+				}
+				Resume ( );
+				break;
+
+			case DBMSG_STEPINTO:
+				mBreakStepInto = true;
+				Resume ( );
+				break;
+
+			case DBMSG_INSPECTVARIABLE:
+				HandleInspectVariable ( &msg );
+				break;
+
+			case DBMSG_INSPECTCALLSTACK:
+				HandleInspectCallstack ( &msg );
+				break;
+
+			case DBMSG_INSPECTTHREADS:
+				HandleInspectThreads ( &msg );
+				break;
+
+			case DBMSG_INSPECTSCRIPTS:
+				HandleInspectScripts( &msg );
+				break;
+
+			case DBMSG_EXECCOMMAND:
+				HandleExecCommand( &msg );
+				break;
+		}
+	}
+
+	return true;
+}
+
+/*
+================
+rvDebuggerServer::SendMessage
+
+Send a message with no data to the debugger server.
+================
+*/
+void rvDebuggerServer::SendMessage ( EDebuggerMessage dbmsg )
+{
+	idBitMsg	 msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	msg.Init( buffer, sizeof( buffer ) );
+	msg.BeginWriting();
+	msg.WriteShort ( (short)dbmsg );
+
+	SendPacket ( msg.GetData(), msg.GetSize() );
+}
+
+/*
+================
+rvDebuggerServer::HandleAddBreakpoint
+
+Handle the DBMSG_ADDBREAKPOINT message being sent by the debugger client.  This
+message is handled by first checking if it is valid
+and is added as a new breakpoint to the breakpoint list with the
+data supplied in the message.
+================
+*/
+void rvDebuggerServer::HandleAddBreakpoint ( idBitMsg* msg )
+{
+	bool onceOnly = false;
+	long lineNumber;
+	long id;
+	char filename[2048]; // DG: randomly chose this size
+
+	// Read the breakpoint info
+	onceOnly = msg->ReadBits( 1 ) ? true : false;
+	lineNumber = msg->ReadInt ( );
+	id		   = msg->ReadInt ( );
+
+	msg->ReadString ( filename, sizeof(filename) );
+
+	//check for statement on requested breakpoint location 
+	if (!gameEdit->IsLineCode(filename, lineNumber))
+	{
+		idBitMsg	msgOut;
+		byte		buffer[MAX_MSGLEN];
+
+		msgOut.Init(buffer, sizeof(buffer));
+		msgOut.BeginWriting();
+		msgOut.WriteShort((short)DBMSG_REMOVEBREAKPOINT);
+		msgOut.WriteInt(lineNumber);
+		msgOut.WriteString(filename);
+		SendPacket(msgOut.GetData(), msgOut.GetSize());
+		return;
+	}
+
+
+	SDL_LockMutex( mCriticalSection );
+	mBreakpoints.Append ( new rvDebuggerBreakpoint ( filename, lineNumber, id, onceOnly ) );
+	SDL_UnlockMutex( mCriticalSection );
+}
+
+/*
+================
+rvDebuggerServer::HandleRemoveBreakpoint
+
+Handle the DBMSG_REMOVEBREAKPOINT message being sent by the debugger client.  This
+message is handled by removing the breakpoint that matches the given id from the
+list.
+================
+*/
+void rvDebuggerServer::HandleRemoveBreakpoint ( idBitMsg* msg )
+{
+	int i;
+	int id;
+
+	// ID that we are to remove
+	id = msg->ReadInt ( );
+
+	// Since breakpoints are used by both threads we need to
+	// protect them with a crit section
+	SDL_LockMutex( mCriticalSection );
+
+	// Find the breakpoint that matches the given id and remove it from the list
+	for ( i = 0; i < mBreakpoints.Num(); i ++ )
+	{
+		if ( mBreakpoints[i]->GetID ( ) == id )
+		{
+			delete mBreakpoints[i];
+			mBreakpoints.RemoveIndex ( i );
+			break;
+		}
+	}
+
+	SDL_UnlockMutex( mCriticalSection );
+}
+
+/*
+================
+rvDebuggerServer::HandleResume
+
+Resume the game thread.
+================
+
+*/
+void rvDebuggerServer::HandleResume(idBitMsg* msg)
+{
+	//Empty msg
+	Resume();
+}
+
+/*
+================
+rvDebuggerServer::HandleInspectCallstack
+
+Handle an incoming inspect callstack message by sending a message
+back to the client with the callstack data.
+================
+*/
+void rvDebuggerServer::HandleInspectCallstack ( idBitMsg* msg )
+{
+	idBitMsg	 msgOut;
+	byte		 buffer[MAX_MSGLEN];
+
+	msgOut.Init(buffer, sizeof( buffer ) );
+	msgOut.BeginWriting();
+	msgOut.WriteShort ( (short)DBMSG_INSPECTCALLSTACK );
+
+	gameEdit->MSG_WriteInterpreterInfo(&msgOut, mBreakInterpreter, mBreakProgram, mBreakInstructionPointer);
+
+	SendPacket (msgOut.GetData(), msgOut.GetSize() );
+}
+
+/*
+================
+rvDebuggerServer::HandleInspectThreads
+
+Send the list of the current threads in the interpreter back to the debugger client
+================
+*/
+void rvDebuggerServer::HandleInspectThreads ( idBitMsg* msg )
+{
+	idBitMsg	msgOut;
+	byte		buffer[MAX_MSGLEN];
+	int			i;
+
+	// Initialize the message
+	msgOut.Init( buffer, sizeof( buffer ) );
+	msgOut.SetAllowOverflow(true);
+	msgOut.BeginWriting();
+	msgOut.WriteShort ( (short)DBMSG_INSPECTTHREADS );
+
+	// Write the number of threads to the message
+	msgOut.WriteShort ((short)gameEdit->GetTotalScriptThreads() );
+
+	// Loop through all of the threads and write their name and number to the message
+	for ( i = 0; i < gameEdit->GetTotalScriptThreads(); i ++ )
+	{
+		gameEdit->MSG_WriteThreadInfo(&msgOut, gameEdit->GetThreadByIndex(i), mBreakInterpreter);
+	}
+
+	// Send off the inspect threads packet to the debugger client
+	SendPacket (msgOut.GetData(), msgOut.GetSize() );
+}
+
+/*
+================
+rvDebuggerServer::HandleExecCommand
+
+Send the list of the current loaded scripts in the interpreter back to the debugger client
+================
+*/
+void rvDebuggerServer::HandleExecCommand( idBitMsg *msg ) {
+	char cmdStr[2048]; // HvG: randomly chose this size
+
+	msg->ReadString( cmdStr, sizeof( cmdStr ) );
+	cmdSystem->BufferCommandText( CMD_EXEC_APPEND, cmdStr );	// valid command
+	cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "\n" );
+}
+
+
+/*
+================
+rvDebuggerServer::HandleInspectScripts
+
+Send the list of the current loaded scripts in the interpreter back to the debugger client
+================
+*/
+void rvDebuggerServer::HandleInspectScripts( idBitMsg* msg )
+{
+	idBitMsg	 msgOut;
+	byte		 buffer[MAX_MSGLEN];
+
+	// Initialize the message
+	msgOut.Init(buffer, sizeof(buffer));
+	msgOut.BeginWriting();
+	msgOut.WriteShort((short)DBMSG_INSPECTSCRIPTS);
+
+	gameEdit->MSG_WriteScriptList( &msgOut );
+
+	SendPacket(msgOut.GetData(), msgOut.GetSize());
+}
+
+/*
+================
+rvDebuggerServer::HandleInspectVariable
+
+Respondes to a request from the debugger client to inspect the value of a given variable
+================
+*/
+void rvDebuggerServer::HandleInspectVariable ( idBitMsg* msg )
+{
+	char varname[256];
+	int  scopeDepth;
+
+	if ( !mBreak )
+	{
+		return;
+	}
+
+	scopeDepth = (short)msg->ReadShort ( );
+	msg->ReadString ( varname, 256 );
+
+	idStr varvalue;
+
+	idBitMsg	 msgOut;
+	byte		 buffer[MAX_MSGLEN];
+
+	// Initialize the message
+	msgOut.Init( buffer, sizeof( buffer ) );
+	msgOut.BeginWriting();
+	msgOut.WriteShort ( (short)DBMSG_INSPECTVARIABLE );
+
+	if (!gameEdit->GetRegisterValue(mBreakInterpreter, varname, varvalue, scopeDepth ) )
+	{
+		varvalue = "???";
+	}
+
+	msgOut.WriteShort ( (short)scopeDepth );
+	msgOut.WriteString ( varname );
+	msgOut.WriteString ( varvalue );
+
+	SendPacket (msgOut.GetData(), msgOut.GetSize() );
+}
+
+/*
+================
+rvDebuggerServer::CheckBreakpoints
+
+Check to see if any breakpoints have been hit.  This includes "break next",
+"step into", and "step over" break points
+================
+*/
+void rvDebuggerServer::CheckBreakpoints	( idInterpreter* interpreter, idProgram* program, int instructionPointer )
+{
+	const char*			filename;
+	int					i;
+
+	if ( !mConnected ) {
+		return;
+	}
+
+	
+	// Grab the current statement and the filename that it came from
+	filename = gameEdit->GetFilenameForStatement(program, instructionPointer);
+	int linenumber = gameEdit->GetLineNumberForStatement(program, instructionPointer);
+
+	// Operate on lines, not statements
+	if ( mLastStatementLine == linenumber && mLastStatementFile == filename)
+	{
+		return;
+	}
+	
+	// Save the last visited line and file so we can prevent
+	// double breaks on lines with more than one statement
+	mLastStatementFile = idStr(filename);
+	mLastStatementLine = linenumber;
+
+	// Reset stepping when the last function on the callstack is returned from
+	if ( gameEdit->ReturnedFromFunction(program, interpreter,instructionPointer))
+	{
+		mBreakStepOver = false;
+		mBreakStepInto = false;
+	}
+
+	// See if we are supposed to break on the next script line
+	if ( mBreakNext )
+	{
+		HandleInspectScripts(NULL);
+		Break ( interpreter, program, instructionPointer );
+		return;
+	}
+
+	// Only break on the same callstack depth and thread as the break over
+	if ( mBreakStepOver )
+	{
+		//virtual bool CheckForBreakpointHit(interpreter,function1,function2,depth)
+		if ( gameEdit->CheckForBreakPointHit(interpreter, mBreakStepOverFunc1, mBreakStepOverFunc2, mBreakStepOverDepth) )
+		{
+			Break ( interpreter, program, instructionPointer );
+			return;
+		}
+	}
+
+	// See if we are supposed to break on the next line
+	if ( mBreakStepInto )
+	{
+		HandleInspectScripts(NULL);
+		// Break
+		Break ( interpreter, program, instructionPointer );
+		return;
+	}
+
+	idStr qpath;
+	OSPathToRelativePath(filename,qpath);
+	qpath.BackSlashesToSlashes ( );
+
+	SDL_LockMutex( mCriticalSection );
+
+	// Check all the breakpoints
+	for ( i = 0; i < mBreakpoints.Num ( ); i ++ )
+	{
+		rvDebuggerBreakpoint* bp = mBreakpoints[i];
+
+		// Skip if not match of the line number
+		if ( linenumber != bp->GetLineNumber ( ) )
+		{
+			continue;
+		}
+
+		// Skip if no match of the filename
+		if ( idStr::Icmp ( bp->GetFilename(), qpath.c_str() ) )
+		{
+			continue;
+		}
+
+		// DG: onceOnly support
+		if ( bp->GetOnceOnly() ) {
+			// we'll do the one Break() a few lines below; remove it here while mBreakpoints is unmodified
+			// (it can be modifed from the client while in Break() below)
+			mBreakpoints.RemoveIndex( i );
+			delete bp;
+
+			// also tell client to remove the breakpoint
+			idBitMsg	msgOut;
+			byte		buffer[MAX_MSGLEN];
+			msgOut.Init( buffer, sizeof( buffer ) );
+			msgOut.BeginWriting();
+			msgOut.WriteShort( (short)DBMSG_REMOVEBREAKPOINT );
+			msgOut.WriteInt( linenumber );
+			msgOut.WriteString( qpath.c_str() );
+			SendPacket( msgOut.GetData(), msgOut.GetSize() );
+		}
+		// DG end
+
+		// Pop out of the critical section so we dont get stuck
+		SDL_UnlockMutex( mCriticalSection );
+
+		HandleInspectScripts(NULL);
+		// We hit a breakpoint, so break
+		Break ( interpreter, program, instructionPointer );
+
+		// Back into the critical section since we are going to have to leave it
+		SDL_LockMutex( mCriticalSection );
+
+		break;
+	}
+
+	SDL_UnlockMutex( mCriticalSection );
+}
+
+/*
+================
+rvDebuggerServer::Break
+
+Halt execution of the game threads and inform the debugger client that
+the game has been halted
+================
+*/
+void rvDebuggerServer::Break ( idInterpreter* interpreter, idProgram* program, int instructionPointer )
+{
+	idBitMsg			msg;
+	byte				buffer[MAX_MSGLEN];
+	const char*			filename;
+
+	// Clear all the break types
+	mBreakStepOver = false;
+	mBreakStepInto = false;
+	mBreakNext     = false;
+
+	// Grab the current statement and the filename that it came from
+	filename = gameEdit->GetFilenameForStatement(program,instructionPointer);
+	int linenumber = gameEdit->GetLineNumberForStatement(program, instructionPointer);
+	idStr fileStr = filename;
+	fileStr.BackSlashesToSlashes();
+
+	// Give the mouse cursor back to the world
+	Sys_GrabMouseCursor( false );
+
+	// Set the break variable so we know the main thread is stopped
+	mBreak = true;
+	mBreakProgram = program;
+	mBreakInterpreter = interpreter;
+	mBreakInstructionPointer = instructionPointer;
+
+	// Inform the debugger of the breakpoint hit
+	msg.Init( buffer, sizeof( buffer ) );
+	msg.BeginWriting();
+	msg.WriteShort ( (short)DBMSG_BREAK );
+	msg.WriteInt ( linenumber );
+	msg.WriteString ( fileStr.c_str() );
+
+	//msg.WriteInt64( (int64_t)mBreakProgram );
+
+	SendPacket ( msg.GetData(), msg.GetSize() );
+
+	// Suspend the game thread.  Since this will be called from within the main game thread
+	// execution wont return until after the thread is resumed
+	// DG: the original code used Win32 SuspendThread() here, but as there is no equivalent
+	//     function in SDL and as this is only called within the main game thread anyway,
+	//     just use a condition variable to put this thread to sleep until Resume() has set mBreak
+	SDL_LockMutex( mGameThreadBreakLock );
+	while ( mBreak ) {
+		SDL_CondWait( mGameThreadBreakCond, mGameThreadBreakLock );
+	}
+	SDL_UnlockMutex( mGameThreadBreakLock );
+
+	// Let the debugger client know that we have started back up again
+	SendMessage ( DBMSG_RESUMED );
+
+	// this should be platform specific
+	// TODO: maybe replace with SDL code? or does it not matter if debugger client runs on another machine?
+#if defined( ID_ALLOW_TOOLS )
+	// This is to give some time between the keypress that
+	// told us to resume and the setforeground window.  Otherwise the quake window
+	// would just flash
+	Sleep ( 150 );
+
+	// Bring the window back to the foreground
+	SetForegroundWindow ( win32.hWnd );
+	SetActiveWindow ( win32.hWnd );
+	UpdateWindow ( win32.hWnd );
+	SetFocus ( win32.hWnd );
+#endif
+
+	// Give the mouse cursor back to the game
+	// HVG_Note : there be dragons here. somewhere.
+	Sys_GrabMouseCursor( true );
+
+	// Clear all commands that were generated before we went into suspended mode.  This is
+	// to ensure we dont have mouse downs with no ups because the context was changed.
+	idKeyInput::ClearStates();
+}
+
+/*
+================
+rvDebuggerServer::Resume
+
+Resume execution of the game.
+================
+*/
+void rvDebuggerServer::Resume ( void )
+{
+	// Cant resume if not paused
+	if ( !mBreak )
+	{
+		return;
+	}
+
+	// Start the game thread back up
+	SDL_LockMutex( mGameThreadBreakLock );
+	mBreak = false;
+	SDL_CondSignal( mGameThreadBreakCond);
+	SDL_UnlockMutex( mGameThreadBreakLock );
+}
+
+/*
+================
+rvDebuggerServer::ClearBreakpoints
+
+Remove all known breakpoints
+================
+*/
+void rvDebuggerServer::ClearBreakpoints	( void )
+{
+	int i;
+
+	for ( i = 0; i < mBreakpoints.Num(); i ++ )
+	{
+		delete mBreakpoints[i];
+	}
+
+	mBreakpoints.Clear ( );
+}
+
+/*
+================
+rvDebuggerServer::Print
+
+Sends a console print message over to the debugger client
+================
+*/
+void rvDebuggerServer::Print ( const char* text )
+{
+	if ( !mConnected )
+	{
+		return;
+	}
+
+	idBitMsg msg;
+	byte	 buffer[MAX_MSGLEN];
+
+	msg.Init( buffer, sizeof( buffer ) );
+	msg.BeginWriting();
+	msg.WriteShort ( (short)DBMSG_PRINT );
+	msg.WriteString ( text );
+
+	SendPacket ( msg.GetData(), msg.GetSize() );
+}

--- a/tools/debugger/DebuggerServer.cpp
+++ b/tools/debugger/DebuggerServer.cpp
@@ -42,14 +42,6 @@ If you have questions concerning this license or the applicable additional terms
 const int MAX_MSGLEN = 8600;
 #endif
 
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-  // compat with SDL2
-  #define SDL_CreateCond SDL_CreateCondition
-  #define SDL_DestroyCond SDL_DestroyCondition
-  #define SDL_CondWait SDL_WaitCondition
-  #define SDL_CondSignal SDL_SignalCondition
-#endif
-
 /*
 ================
 rvDebuggerServer::rvDebuggerServer
@@ -62,8 +54,7 @@ rvDebuggerServer::rvDebuggerServer ( )
 	mBreak				= false;
 	mBreakStepOver		= false;
 	mBreakStepInto		= false;
-	mGameThreadBreakCond = NULL;
-	mGameThreadBreakLock = NULL;
+	// TODO: clear mGameThreadBreakSignal ?
 	mLastStatementLine	= -1;
 	mBreakStepOverFunc1 = NULL;
 	mBreakStepOverFunc2 = NULL;
@@ -72,7 +63,7 @@ rvDebuggerServer::rvDebuggerServer ( )
 	mBreakProgram = NULL;
 	mGameDLLHandle = 0;
 	mBreakStepOverDepth = 0;
-	mCriticalSection = NULL;
+	//mCriticalSection = 0; - TODO: clear somehow?
 }
 
 /*
@@ -100,14 +91,13 @@ bool rvDebuggerServer::Initialize ( void )
 		return false;
 	}
 
-	// we're using a condition variable to pause the game thread in rbDebuggerServer::Break()
+	// we're using a signal to pause the game thread in rbDebuggerServer::Break()
 	// until rvDebuggerServer::Resume() is called (from another thread)
-	mGameThreadBreakCond = SDL_CreateCond();
-	mGameThreadBreakLock = SDL_CreateMutex();
+	Sys_SignalCreate( mGameThreadBreakSignal, true );
 
 	// Create a critical section to ensure that the shared thread
 	// variables are protected
-	mCriticalSection = SDL_CreateMutex();
+	Sys_MutexCreate( mCriticalSection );
 
 	// Server must be running on the local host on port 28980
 	Sys_StringToNetAdr ( com_dbgClientAdr.GetString( ), &mClientAdr, true );
@@ -152,14 +142,13 @@ void rvDebuggerServer::Shutdown ( void )
 
 	Resume(); // just in case we're still paused
 
-	// dont need the crit section anymore
-	SDL_DestroyMutex( mCriticalSection );
-	mCriticalSection = NULL;
+	// don't need the crit section anymore
+	Sys_MutexDestroy( mCriticalSection );
+	//mCriticalSection = NULL; TODO clear?
 
-	SDL_DestroyCond( mGameThreadBreakCond );
-	mGameThreadBreakCond = NULL;
-	SDL_DestroyMutex( mGameThreadBreakLock );
-	mGameThreadBreakLock = NULL;
+
+	Sys_SignalDestroy( mGameThreadBreakSignal );
+	// TODO: clear mGameThreadBreakSignal ?
 }
 
 /*
@@ -334,9 +323,9 @@ void rvDebuggerServer::HandleAddBreakpoint ( idBitMsg* msg )
 	}
 
 
-	SDL_LockMutex( mCriticalSection );
+	Sys_MutexLock( mCriticalSection, true );
 	mBreakpoints.Append ( new rvDebuggerBreakpoint ( filename, lineNumber, id, onceOnly ) );
-	SDL_UnlockMutex( mCriticalSection );
+	Sys_MutexUnlock( mCriticalSection );
 }
 
 /*
@@ -358,7 +347,7 @@ void rvDebuggerServer::HandleRemoveBreakpoint ( idBitMsg* msg )
 
 	// Since breakpoints are used by both threads we need to
 	// protect them with a crit section
-	SDL_LockMutex( mCriticalSection );
+	Sys_MutexLock( mCriticalSection, true );
 
 	// Find the breakpoint that matches the given id and remove it from the list
 	for ( i = 0; i < mBreakpoints.Num(); i ++ )
@@ -371,7 +360,7 @@ void rvDebuggerServer::HandleRemoveBreakpoint ( idBitMsg* msg )
 		}
 	}
 
-	SDL_UnlockMutex( mCriticalSection );
+	Sys_MutexUnlock( mCriticalSection );
 }
 
 /*
@@ -594,7 +583,7 @@ void rvDebuggerServer::CheckBreakpoints	( idInterpreter* interpreter, idProgram*
 	OSPathToRelativePath(filename,qpath);
 	qpath.BackSlashesToSlashes ( );
 
-	SDL_LockMutex( mCriticalSection );
+	Sys_MutexLock( mCriticalSection, true );
 
 	// Check all the breakpoints
 	for ( i = 0; i < mBreakpoints.Num ( ); i ++ )
@@ -633,19 +622,19 @@ void rvDebuggerServer::CheckBreakpoints	( idInterpreter* interpreter, idProgram*
 		// DG end
 
 		// Pop out of the critical section so we dont get stuck
-		SDL_UnlockMutex( mCriticalSection );
+		Sys_MutexUnlock( mCriticalSection );
 
 		HandleInspectScripts(NULL);
 		// We hit a breakpoint, so break
 		Break ( interpreter, program, instructionPointer );
 
 		// Back into the critical section since we are going to have to leave it
-		SDL_LockMutex( mCriticalSection );
+		Sys_MutexLock( mCriticalSection, true );
 
 		break;
 	}
 
-	SDL_UnlockMutex( mCriticalSection );
+	Sys_MutexUnlock( mCriticalSection );
 }
 
 /*
@@ -695,20 +684,18 @@ void rvDebuggerServer::Break ( idInterpreter* interpreter, idProgram* program, i
 
 	// Suspend the game thread.  Since this will be called from within the main game thread
 	// execution wont return until after the thread is resumed
-	// DG: the original code used Win32 SuspendThread() here, but as there is no equivalent
-	//     function in SDL and as this is only called within the main game thread anyway,
-	//     just use a condition variable to put this thread to sleep until Resume() has set mBreak
-	SDL_LockMutex( mGameThreadBreakLock );
-	while ( mBreak ) {
-		SDL_CondWait( mGameThreadBreakCond, mGameThreadBreakLock );
-	}
-	SDL_UnlockMutex( mGameThreadBreakLock );
+	// DG: the original code used Win32 SuspendThread() here, but as we have no equivalent
+	//     function in sys_threading.h and as this is only called within the main game thread anyway,
+	//     just use a signal to put this thread to sleep until Resume() has set mBreak
+	// first make sure the signal is cleared (so wait actually blocks)
+	Sys_SignalClear( mGameThreadBreakSignal );
+	// now wait for Resume() to raise the signal (from the debugger thread)
+	Sys_SignalWait( mGameThreadBreakSignal, idSysSignal::WAIT_INFINITE );
 
 	// Let the debugger client know that we have started back up again
 	SendMessage ( DBMSG_RESUMED );
 
 	// this should be platform specific
-	// TODO: maybe replace with SDL code? or does it not matter if debugger client runs on another machine?
 #if defined( ID_ALLOW_TOOLS )
 	// This is to give some time between the keypress that
 	// told us to resume and the setforeground window.  Otherwise the quake window
@@ -747,10 +734,8 @@ void rvDebuggerServer::Resume ( void )
 	}
 
 	// Start the game thread back up
-	SDL_LockMutex( mGameThreadBreakLock );
 	mBreak = false;
-	SDL_CondSignal( mGameThreadBreakCond);
-	SDL_UnlockMutex( mGameThreadBreakLock );
+	Sys_SignalRaise( mGameThreadBreakSignal );
 }
 
 /*

--- a/tools/debugger/DebuggerServer.cpp
+++ b/tools/debugger/DebuggerServer.cpp
@@ -32,7 +32,6 @@ If you have questions concerning this license or the applicable additional terms
 
 
 #if defined( ID_ALLOW_TOOLS )
-#include "tools/edit_gui_common.h"
 #include "DebuggerServer.h"
 #include "DebuggerApp.h"
 #else
@@ -410,7 +409,6 @@ void rvDebuggerServer::HandleInspectThreads ( idBitMsg* msg )
 {
 	idBitMsg	msgOut;
 	byte		buffer[MAX_MSGLEN];
-	int			i;
 
 	// Initialize the message
 	msgOut.Init( buffer, sizeof( buffer ) );
@@ -422,9 +420,12 @@ void rvDebuggerServer::HandleInspectThreads ( idBitMsg* msg )
 	msgOut.WriteShort ((short)gameEdit->GetTotalScriptThreads() );
 
 	// Loop through all of the threads and write their name and number to the message
-	for ( i = 0; i < gameEdit->GetTotalScriptThreads(); i ++ )
+	for ( int i = 0, n=gameEdit->GetTotalScriptThreads(); i < n; i++ )
 	{
-		gameEdit->MSG_WriteThreadInfo(&msgOut, gameEdit->GetThreadByIndex(i), mBreakInterpreter);
+		const idThread* t = gameEdit->GetThreadByIndex(i);
+		if ( t != NULL ) {
+			gameEdit->MSG_WriteThreadInfo(&msgOut, t, mBreakInterpreter);
+		}
 	}
 
 	// Send off the inspect threads packet to the debugger client

--- a/tools/debugger/DebuggerServer.h
+++ b/tools/debugger/DebuggerServer.h
@@ -28,20 +28,12 @@ If you have questions concerning this license or the applicable additional terms
 #ifndef DEBUGGERSERVER_H_
 #define DEBUGGERSERVER_H_
 
-// FIXME #include "sys/sys_sdl.h"
-
-//#include "sys/platform.h"
+#include "sys/sys_threading.h"
 #include "sys/sys_public.h"
 #include "idlib/Str.h"
 #include "DebuggerMessages.h"
 #include "DebuggerBreakpoint.h"
 #include "game/Game.h"
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-  // backwards-compat with SDL <= 2
-  #define SDL_mutex SDL_Mutex
-  #define SDL_cond SDL_Condition
-#endif
 
 class function_t;
 typedef struct prstack_s prstack_t;
@@ -92,11 +84,9 @@ private:
 	netadr_t						mClientAdr;
 	idPort							mPort;
 	idList<rvDebuggerBreakpoint*>	mBreakpoints;
-	SDL_mutex*						mCriticalSection;
+	mutexHandle_t					mCriticalSection;
 
-
-	SDL_cond*						mGameThreadBreakCond;
-	SDL_mutex*						mGameThreadBreakLock;
+	signalHandle_t					mGameThreadBreakSignal;
 	bool							mBreak;
 
 	bool							mBreakNext;

--- a/tools/debugger/DebuggerServer.h
+++ b/tools/debugger/DebuggerServer.h
@@ -1,0 +1,149 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERSERVER_H_
+#define DEBUGGERSERVER_H_
+
+// FIXME #include "sys/sys_sdl.h"
+
+//#include "sys/platform.h"
+#include "sys/sys_public.h"
+#include "idlib/Str.h"
+#include "DebuggerMessages.h"
+#include "DebuggerBreakpoint.h"
+#include "game/Game.h"
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+  // backwards-compat with SDL <= 2
+  #define SDL_mutex SDL_Mutex
+  #define SDL_cond SDL_Condition
+#endif
+
+class function_t;
+typedef struct prstack_s prstack_t;
+
+class rvDebuggerServer
+{
+public:
+
+	rvDebuggerServer ( );
+	~rvDebuggerServer ( );
+
+	bool		Initialize				( void );
+	void		Shutdown				( void );
+
+	bool		ProcessMessages			( void );
+
+	bool		IsConnected				( void );
+
+	void		CheckBreakpoints		( idInterpreter *interpreter, idProgram *program, int instructionPointer );
+
+	void		Print					( const char *text );
+
+	void		OSPathToRelativePath	( const char *osPath, idStr &qpath );
+
+	bool		GameSuspended			( void );
+private:
+
+	void		ClearBreakpoints		( void );
+
+	void		Break					( idInterpreter *interpreter, idProgram *program, int instructionPointer );
+	void		Resume					( void );
+
+	void		SendMessage				( EDebuggerMessage dbmsg );
+	void		SendPacket				( void* data, int datasize );
+
+	// Message handlers
+	void		HandleAddBreakpoint		( idBitMsg *msg );
+	void		HandleRemoveBreakpoint	( idBitMsg *msg );
+	void		HandleResume			( idBitMsg *msg );
+	void		HandleInspectVariable	( idBitMsg *msg );
+	void		HandleInspectCallstack	( idBitMsg *msg );
+	void		HandleInspectThreads	( idBitMsg *msg );
+	void		HandleInspectScripts	( idBitMsg *msg );
+	void		HandleExecCommand		( idBitMsg *msg );
+	////
+
+	bool							mConnected;
+	netadr_t						mClientAdr;
+	idPort							mPort;
+	idList<rvDebuggerBreakpoint*>	mBreakpoints;
+	SDL_mutex*						mCriticalSection;
+
+
+	SDL_cond*						mGameThreadBreakCond;
+	SDL_mutex*						mGameThreadBreakLock;
+	bool							mBreak;
+
+	bool							mBreakNext;
+	bool							mBreakStepOver;
+	bool							mBreakStepInto;
+	int								mBreakStepOverDepth;
+	const function_t*				mBreakStepOverFunc1;
+	const function_t*				mBreakStepOverFunc2;
+	idProgram*						mBreakProgram;
+	int								mBreakInstructionPointer;
+	idInterpreter*					mBreakInterpreter;
+
+	idStr							mLastStatementFile;
+	int								mLastStatementLine;
+	uintptr_t						mGameDLLHandle;
+	idStrList						mScriptFileList;
+
+};
+
+/*
+================
+rvDebuggerServer::IsConnected
+================
+*/
+ID_INLINE bool rvDebuggerServer::IsConnected ( void )
+{
+	return mConnected;
+}
+
+/*
+================
+rvDebuggerServer::SendPacket
+================
+*/
+ID_INLINE void rvDebuggerServer::SendPacket ( void *data, int size )
+{
+	mPort.SendPacket ( mClientAdr, data, size );
+}
+
+/*
+================
+rvDebuggerServer::GameSuspended
+================
+*/
+ID_INLINE bool rvDebuggerServer::GameSuspended( void )
+{
+	return mBreak;
+}
+
+#endif // DEBUGGERSERVER_H_

--- a/tools/debugger/DebuggerWindow.cpp
+++ b/tools/debugger/DebuggerWindow.cpp
@@ -1,0 +1,2745 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "tools/edit_gui_common.h"
+
+
+#include "../../sys/win32/rc/debugger_resource.h"
+#include "DebuggerApp.h"
+#include "../Common/OpenFileDialog.h"
+#include "DebuggerQuickWatchDlg.h"
+#include "DebuggerFindDlg.h"
+
+#define DEBUGGERWINDOWCLASS		"DHEWM3_DEBUGGER_WINDOW"
+#define ID_DBG_WINDOWMIN		18900
+#define ID_DBG_WINDOWMAX		19900
+
+#define	IDC_DBG_SCRIPT			31000
+#define	IDC_DBG_OUTPUT			31001
+#define IDC_DBG_SPLITTER		31002
+#define IDC_DBG_TABS			31003
+#define IDC_DBG_BORDER			31004
+#define IDC_DBG_CONSOLE			31005
+#define IDC_DBG_CALLSTACK		31006
+#define IDC_DBG_WATCH			31007
+#define IDC_DBG_THREADS			31008
+#define IDC_DBG_TOOLBAR			31009
+#define IDC_DBG_SCRIPTLIST		31010
+#define IDC_DBG_CONSOLEINPUT	31011
+#define IDC_DBG_BREAKLIST		31012
+
+#define ID_DBG_FILE_MRU1		10000
+
+/*
+================
+rvDebuggerWindow::rvDebuggerWindow
+
+Constructor
+================
+*/
+rvDebuggerWindow::rvDebuggerWindow ( )
+{
+	mWnd		   = NULL;
+	mWndScript	   = NULL;
+	mInstance	   = NULL;
+	mZoomScaleNum  = 0;
+	mZoomScaleDem  = 0;
+	mWindowMenuPos = 0;
+	mActiveScript  = 0;
+	mSplitterDrag  = false;
+	mLastActiveScript = -1;
+	mCurrentStackDepth = 0;
+	mRecentFileInsertPos = 0;
+	mRecentFileMenu = NULL;
+	mClient = NULL;
+}
+
+/*
+================
+rvDebuggerWindow::~rvDebuggerWindow
+
+Destructor
+================
+*/
+rvDebuggerWindow::~rvDebuggerWindow ( )
+{
+	int i;
+
+	if ( mWnd )
+	{
+		DestroyWindow ( mWnd );
+	}
+
+	if ( mImageList )
+	{
+		ImageList_Destroy ( mImageList );
+	}
+
+	for ( i = 0; i < mScripts.Num (); i ++ )
+	{
+		delete mScripts[i];
+	}
+}
+
+/*
+================
+rvDebuggerWindow::RegisterClass
+
+Registers the window class used by the debugger window.  This is called when
+the window is created.
+================
+*/
+bool rvDebuggerWindow::RegisterClass ( void )
+{
+	WNDCLASSEX wcex;
+
+	wcex.cbSize = sizeof(WNDCLASSEX);
+
+	wcex.style			= CS_HREDRAW | CS_VREDRAW;
+	wcex.lpfnWndProc	= (WNDPROC)WndProc;
+	wcex.cbClsExtra		= 0;
+	wcex.cbWndExtra		= 0;
+	wcex.hInstance		= mInstance;
+	wcex.hIcon			= NULL;
+	wcex.hCursor		= LoadCursor(NULL, IDC_ARROW);
+	wcex.hbrBackground	= (HBRUSH)(COLOR_APPWORKSPACE+1);
+	wcex.lpszMenuName	= MAKEINTRESOURCE(IDR_DBG_MAIN);
+	wcex.lpszClassName	= DEBUGGERWINDOWCLASS;
+	wcex.hIconSm		= NULL;
+
+	return RegisterClassEx(&wcex) ? true : false;
+}
+
+/*
+================
+rvDebuggerWindow::Create
+
+Creates the debugger window
+================
+*/
+bool rvDebuggerWindow::Create ( HINSTANCE instance )
+{
+	mInstance = instance;
+
+	if ( !RegisterClass ( ) )
+	{
+		return false;
+	}
+
+	// Cache the client pointer for ease of use
+	mClient = &gDebuggerApp.GetClient();
+
+	// Create the debugger window
+	mWnd = CreateWindow( DEBUGGERWINDOWCLASS, "",
+						 WS_OVERLAPPEDWINDOW,
+						 CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, NULL, NULL, mInstance, this);
+
+	if ( !mWnd )
+	{
+		return false;
+	}
+
+	// Determine where the window names will be added in the menus
+	mWindowMenu    = GetSubMenu ( GetMenu ( mWnd ), 2 );
+	mWindowMenuPos = GetMenuItemCount ( mWindowMenu );
+
+	UpdateTitle ( );
+
+	Printf ( "Dhewm3 Script Debugger v1.1\n\n" );
+
+	ShowWindow ( mWnd, SW_SHOW );
+	UpdateWindow ( mWnd );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerWindow::ScriptWordBreakProc
+
+Determines where word breaks are in the script window.  This is used for determining
+the word that someone is over with their mouse cursor.  Since the default windows one
+doesnt understand the delimiters of the scripting language it had to be overridden.
+================
+*/
+int CALLBACK rvDebuggerWindow::ScriptWordBreakProc (LPTSTR text, int current, int max, int action )
+{
+	static TCHAR delimiters[]=TEXT("!@#$%^&*()-+=[]{}|\\;:'\"/,.<>? \t\r\n") ;
+
+	switch ( action )
+	{
+		default:
+			break;
+
+		case WB_ISDELIMITER:
+			return _tcschr ( delimiters, *(text + current * 2) ) ? TRUE : FALSE;
+
+		case WB_MOVEWORDLEFT:
+		case WB_LEFT:
+
+			current--;
+
+			// Run as long as the current index is valid.
+			while ( current > 0 )
+			{
+				// If we hit a delimiter then return the index + 1 since
+				// it was the last character we were on that was valid
+				if ( _tcschr ( delimiters, *(text + current * 2) ) )
+				{
+					return current + 1;
+				}
+
+				// Going backwards
+				current--;
+			}
+
+			return current;
+
+		case WB_MOVEWORDRIGHT:
+		case WB_RIGHT:
+
+			// If we are already on a delimiter then just return the current index
+			if ( _tcschr ( delimiters, *(text + current * 2) ) )
+			{
+				return current;
+			}
+
+			// Run until we hit the end of the control
+			while ( current < max )
+			{
+				// If we found a delimiter then return the index we are on
+				if ( _tcschr ( delimiters, *(text + current * 2) ) )
+				{
+					return current;
+				}
+
+				current++;
+			}
+
+			return current;
+	}
+
+	return 0;
+  }
+
+LRESULT CALLBACK rvDebuggerWindow::ScriptWndProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+	static int		  lastStart = -1;
+	static int		  lastEnd   = -1;
+	rvDebuggerWindow* window    = (rvDebuggerWindow*)GetWindowLongPtr ( wnd, GWLP_USERDATA );
+	WNDPROC			  wndproc   = window->mOldScriptProc;
+
+	switch ( msg )
+	{
+		case WM_RBUTTONUP:
+			return SendMessage ( wnd, WM_LBUTTONUP, wparam, lparam );
+
+		case WM_RBUTTONDOWN:
+		{
+			POINT point = { LOWORD(lparam), HIWORD(lparam) };
+			HMENU menu;
+			SendMessage ( wnd, WM_LBUTTONDOWN, wparam, lparam );
+			menu = LoadMenu ( window->mInstance, MAKEINTRESOURCE(IDR_DBG_SCRIPT_POPUP) );
+			ClientToScreen ( wnd, &point );
+			TrackPopupMenu ( GetSubMenu( menu, 0 ), TPM_RIGHTBUTTON|TPM_LEFTALIGN, point.x, point.y, 0, window->mWnd, NULL );
+			DestroyMenu ( menu );
+			return 0;
+		}
+
+		case WM_MOUSEMOVE:
+		{
+			// Figure out the start and end of the mouse is over
+			POINTL pos   = {LOWORD(lparam),HIWORD(lparam)};
+			int    c     = SendMessage ( wnd, EM_CHARFROMPOS, 0, (WPARAM)&pos );
+			int    start = SendMessage ( wnd, EM_FINDWORDBREAK, WB_LEFT, c );
+			int    end   = SendMessage ( wnd, EM_FINDWORDBREAK, WB_RIGHT, c );
+
+			// If the start and the end of the word we are over havent changed
+			// then the word hasnt changed so no need to re-setup the tool tip
+			if ( lastStart == start && lastEnd == end )
+			{
+				break;
+			}
+
+			// Save the current start and end for the next mouse move
+			lastStart = start;
+			lastEnd   = end;
+
+			// Get rid of the last tool tip if there is one
+			if ( window->mTooltipVar.Length() )
+			{
+				TOOLINFO ti;
+				ti.cbSize = sizeof(TOOLINFO);
+				ti.hwnd   = wnd;
+				ti.uId    = 0;
+				SendMessage ( window->mWndToolTips, TTM_DELTOOL, 0, (LPARAM) (LPTOOLINFO) &ti );
+				window->mTooltipVar.Empty ( );
+			}
+
+			// If there is no word then ignore it
+			if ( start == end )
+			{
+				break;
+			}
+
+			TEXTRANGE	range;
+			TOOLINFO	ti;
+
+			// grab the actual word from the edit control
+			char* temp = new char[end-start+10];
+			range.chrg.cpMin = start;
+			range.chrg.cpMax = end;
+			range.lpstrText  = temp;
+			SendMessage ( wnd, EM_GETTEXTRANGE, 0, (LPARAM) &range );
+			window->mTooltipVar = temp;
+			delete[] temp;
+
+			// Request the variable's value from the debugger server
+			window->mClient->InspectVariable ( window->mTooltipVar.c_str(), window->mCurrentStackDepth );
+
+			// Prepare to add the new tooltip
+			ti.cbSize   = sizeof(TOOLINFO);
+			ti.uFlags   = TTF_SUBCLASS;
+			ti.hwnd     = wnd;
+			ti.hinst    = (HINSTANCE)GetModuleHandle(NULL);
+			ti.uId      = 0;
+			ti.lpszText = (LPSTR)window->mTooltipVar.c_str();
+
+			// Calculate the bounding box around the word we are over.  We do this
+			// by getting to the top left from the start character and the right side
+			// from the end character.  The bottom is the top from the start character
+			// plus the height of one line
+			SendMessage ( wnd, EM_POSFROMCHAR, (WPARAM)&pos, start );
+			ti.rect.left = pos.x;
+			ti.rect.top  = pos.y;
+			SendMessage ( wnd, EM_POSFROMCHAR, (WPARAM)&pos, end );
+			ti.rect.right = pos.x;
+			SendMessage ( wnd, EM_POSFROMCHAR, (WPARAM)&pos, SendMessage ( wnd, EM_LINEINDEX, 0, 0 ) );
+			ti.rect.bottom = ti.rect.top - pos.y;
+			SendMessage ( wnd, EM_POSFROMCHAR, (WPARAM)&pos, SendMessage ( wnd, EM_LINEINDEX, 1, 0 ) );
+			ti.rect.bottom = ti.rect.bottom + pos.y;
+
+			// Add the new tool tip to the control
+			SendMessage ( window->mWndToolTips, TTM_ADDTOOL, 0, (LPARAM) (LPTOOLINFO) &ti );
+			SendMessage ( window->mWndToolTips, TTM_UPDATE, 0, 0 );
+
+			break;
+		}
+		case WM_SIZE:
+		{
+			float scaling_factor = Win_GetWindowScalingFactor(wnd);
+			int s18 = int(18 * scaling_factor);
+			int s10 = int(10 * scaling_factor);
+
+			RECT rect;
+			window->mMarginSize = window->mZoomScaleDem ? ((long)(s18 * (float)window->mZoomScaleNum / (float)window->mZoomScaleDem)) : s18;
+
+			GetWindowRect(window->mWndToolbar, &rect);
+			MoveWindow(window->mWndMargin, 0, 0, window->mMarginSize, window->mSplitterRect.top - (rect.bottom - rect.top), TRUE);
+			// FIXME: was *2.25, increased for line numbers up to 9999; but neither works particularly well
+			//        if DPI scaling is involved, because script code text and linenumbers aren't DPI scaled
+			int lmargin = window->GetMarginWidth();
+			SendMessage(window->mWndScript, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG(lmargin, s10));
+
+		}
+	}
+
+	return CallWindowProc ( wndproc, wnd, msg, wparam, lparam );
+}
+
+LRESULT CALLBACK rvDebuggerWindow::MarginWndProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+	rvDebuggerWindow* window = (rvDebuggerWindow*) GetWindowLongPtr ( wnd, GWLP_USERDATA );
+
+	switch ( msg )
+	{
+		case WM_RBUTTONDOWN:
+			return SendMessage ( window->mWndScript, WM_RBUTTONDOWN, wparam, lparam );
+
+		case WM_RBUTTONUP:
+			return SendMessage ( window->mWndScript, WM_RBUTTONUP, wparam, lparam );
+
+		case WM_LBUTTONDBLCLK:
+		{
+			int result = SendMessage ( window->mWndScript, WM_LBUTTONDBLCLK, wparam, lparam );
+			window->ToggleBreakpoint ( );
+			return result;
+		}
+
+		case WM_LBUTTONDOWN:
+		{
+			int result = SendMessage ( window->mWndScript, WM_LBUTTONDOWN, wparam, lparam );
+			window->ToggleBreakpoint ( );
+			return result;
+		}
+
+		case WM_LBUTTONUP:
+			return SendMessage ( window->mWndScript, WM_LBUTTONUP, wparam, lparam );
+
+		case WM_PAINT:
+		{
+			HDC dc;
+			float scaling_factor = Win_GetWindowScalingFactor(wnd);
+			int s2 = int(2 * scaling_factor);
+			int s4 = int(4 * scaling_factor);
+			int width,height;
+
+			window->ResizeImageList(width,height);
+
+			PAINTSTRUCT ps;
+			RECT rect;
+			GetClientRect ( wnd, &rect );
+			dc = BeginPaint( wnd, &ps );
+			FillRect( dc, &rect, GetSysColorBrush( COLOR_3DSHADOW ) );
+
+			//draw line nrs
+			int iMaxNumberOfLines = ( (rect.bottom - rect.top ) / height ) + height;
+			int iFirstVisibleLine = SendMessage( window->mWndScript, EM_GETFIRSTVISIBLELINE, 0, 0 );
+			HFONT hf = CreateFont( height, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Courier New" );
+			HFONT hfOld = ( HFONT ) SelectObject( dc, hf );
+			SetBkMode( dc, OPAQUE );
+			// I think it looks nicer when the  line number background is white
+			SetBkColor( dc, RGB( 255, 255, 255 ) );
+			SetTextColor( dc, RGB( 0, 0, 255 ) );
+			
+			int lnrWidth = 8;
+			GetCharWidth32( dc, '9', '9', &lnrWidth );
+			lnrWidth *= 4; // we want enough width for 4 chars ("9999"), not just one
+			lnrWidth += 2 * s4; // we want some space around the line number
+
+			RECT lnrRect = rect;
+			lnrRect.left = rect.right;
+			lnrRect.right = lnrRect.left + lnrWidth;
+			FillRect( dc, &lnrRect, WHITE_BRUSH );
+
+			for (int i = 0; i < iMaxNumberOfLines; ++i )
+			{
+				int		c;
+				POINTL	pos;
+				c = SendMessage( window->mWndScript, EM_LINEINDEX, iFirstVisibleLine + i , 0 );
+				SendMessage( window->mWndScript, EM_POSFROMCHAR, ( WPARAM ) &pos, c );
+
+				RECT t = lnrRect;
+				t.top = pos.y;
+				t.bottom = t.top + height;
+				t.right -= s4; // a little space between text and "border" to code part of window
+				
+				idStr lntxt( iFirstVisibleLine + i + 1);
+				DrawText( dc, lntxt, lntxt.Length(), &t, DT_RIGHT );
+			}
+			DeleteObject( hf );
+
+			//draw breakpoints
+			if ( window->mScripts.Num ( ) )
+			{
+				for ( int i = 0; i < window->mClient->GetBreakpointCount(); i ++ )
+				{
+					rvDebuggerBreakpoint* bp = window->mClient->GetBreakpoint ( i );
+					assert( bp );
+
+					if ( !idStr::Icmp ( window->mScripts[window->mActiveScript]->GetFilename ( ), bp->GetFilename ( ) ) )
+					{
+						int		c;
+						POINTL	pos;
+
+						c = SendMessage ( window->mWndScript, EM_LINEINDEX, bp->GetLineNumber ( ) - 1, 0 );
+						SendMessage ( window->mWndScript, EM_POSFROMCHAR, (WPARAM)&pos, c );
+						ImageList_DrawEx ( window->mTmpImageList, 2, dc, rect.left, pos.y, width, height, CLR_NONE, CLR_NONE, ILD_NORMAL );
+
+					}
+				}
+
+				if ( window->mClient->IsStopped ( ) )
+				{
+					if ( !idStr::Icmp ( window->mClient->GetBreakFilename(),
+										window->mScripts[window->mActiveScript]->GetFilename ( ) ) )
+					{
+						int		c;
+						POINTL	pos;
+
+						c = SendMessage ( window->mWndScript, EM_LINEINDEX, window->mClient->GetBreakLineNumber() - 1, 0 );
+						SendMessage ( window->mWndScript, EM_POSFROMCHAR, (WPARAM)&pos, c );
+						ImageList_DrawEx ( window->mTmpImageList, 3, dc, rect.left, pos.y, width, height, CLR_NONE, CLR_NONE, ILD_NORMAL );
+					}
+				}
+
+				if ( window->mCurrentStackDepth != 0 )
+				{
+					if ( !window->mClient->GetCallstack()[window->mCurrentStackDepth]->mFilename.Icmp ( window->mScripts[window->mActiveScript]->GetFilename ( ) ) )
+					{
+						int		c;
+						POINTL	pos;
+
+						c = SendMessage ( window->mWndScript, EM_LINEINDEX, window->mClient->GetCallstack()[window->mCurrentStackDepth]->mLineNumber - 1, 0 );
+						SendMessage ( window->mWndScript, EM_POSFROMCHAR, (WPARAM)&pos, c );
+						ImageList_DrawEx ( window->mTmpImageList, 1, dc, rect.left, pos.y, width, height, CLR_NONE, CLR_NONE, ILD_NORMAL );
+					}
+				}
+			}
+			RECT tmp = rect;
+
+			rect.right -= s2;
+			rect.left = rect.right + s2;
+			HPEN pen = CreatePen ( PS_SOLID, s2, GetSysColor ( COLOR_BACKGROUND ) );
+			HPEN old = (HPEN)SelectObject ( dc, pen );
+			MoveToEx ( dc, rect.right, rect.top, NULL );
+			LineTo ( dc, rect.right, rect.bottom );
+			
+			SelectObject ( dc, old );
+			DeleteObject ( pen );
+			EndPaint ( wnd, &ps );
+			break;
+		}
+	}
+
+	return DefWindowProc ( wnd, msg, wparam, lparam );
+}
+
+/*
+================
+rvDebuggerWindow::UpdateTitle
+
+Updates the window title of the script debugger to show a few states
+================
+*/
+void rvDebuggerWindow::UpdateTitle ( void )
+{
+	idStr title;
+
+	title = "Dhewm3 Script Debugger - ";
+
+	if ( mClient->IsConnected ( ) )
+	{
+		if ( mClient->IsStopped ( ) )
+		{
+			title += "[break]";
+		}
+		else
+		{
+			title += "[run]";
+		}
+	}
+	else
+	{
+		title += "[disconnected]";
+	}
+
+	if ( mScripts.Num ( ) )
+	{
+		title += " - [";
+		if (mActiveScript != -1)
+			title += idStr( mScripts[mActiveScript]->GetFilename() ).StripPath ( );
+		else
+			title += "Load Error";
+		title += "]";
+	}
+
+	SetWindowText ( mWnd, title );
+}
+
+/*
+================
+rvDebuggerWindow::UpdateScript
+
+Updates the edit window to contain the current script
+================
+*/
+void rvDebuggerWindow::UpdateScript ( void )
+{
+	UpdateTitle ( );
+
+	// Dont reupdate if the given active script is the one being displayed.
+	if ( mActiveScript == mLastActiveScript )
+	{
+		return;
+	}
+
+	mLastActiveScript = mActiveScript;
+
+	// Show and hide the script window depending on whether or not
+	// there are loaded scripts
+	if ( mScripts.Num ( ) < 1 )
+	{
+		ShowWindow ( mWndScript, SW_HIDE );
+		return;
+	}
+	else
+	{
+		ShowWindow ( mWndScript, SW_SHOW );
+	}
+
+	// Update the script
+	SendMessage ( mWndScript, EM_SETSEL, 0, -1 );
+	SendMessage ( mWndScript, EM_REPLACESEL, 0, (LPARAM)"" );
+	SendMessage ( mWndScript, EM_SETSEL, 0, -1 );
+	SendMessage ( mWndScript, EM_REPLACESEL, 0, (LPARAM)mScripts[mActiveScript]->GetContents ( ) );
+}
+
+/*
+================
+rvDebuggerWindow::UpdateWindowMenu
+
+Updates the windows displayed in the window menu
+================
+*/
+void rvDebuggerWindow::UpdateWindowMenu ( void )
+{
+	while ( GetMenuItemCount ( mWindowMenu ) > mWindowMenuPos )
+	{
+		DeleteMenu ( mWindowMenu, mWindowMenuPos, MF_BYPOSITION );
+	}
+
+	if ( mScripts.Num() )
+	{
+		AppendMenu ( mWindowMenu, MF_SEPARATOR, 0, "" );
+	}
+
+	int i;
+	for ( i = 0; i < mScripts.Num(); i ++ )
+	{
+		idStr name;
+		name = mScripts[i]->GetFilename ( );
+		name.StripPath ( );
+		name = idStr(va("&%d ", i + 1 )) + name;
+		AppendMenu ( mWindowMenu, MF_STRING, ID_DBG_WINDOWMIN + i, name );
+	}
+}
+
+/*
+================
+rvDebuggerWindow::UpdateCallstack
+
+Updates the contents of teh callastack
+================
+*/
+void rvDebuggerWindow::UpdateCallstack ( void )
+{
+	LVITEM item;
+	ListView_DeleteAllItems ( mWndCallstack );
+	ZeroMemory ( &item, sizeof(item) );
+	item.mask = LVIF_TEXT|LVIF_IMAGE;
+
+	for ( int i = 0; i < mClient->GetCallstack().Num(); i ++ )
+	{
+		rvDebuggerCallstack* entry = mClient->GetCallstack()[i];
+		item.iItem = ListView_GetItemCount ( mWndCallstack );
+		item.pszText = "";
+		item.iImage = (i == mCurrentStackDepth) ? 1 : 0;
+		ListView_InsertItem ( mWndCallstack, &item );
+
+		ListView_SetItemText ( mWndCallstack, item.iItem, 1, (LPSTR)entry->mFunction.c_str() );
+		ListView_SetItemText ( mWndCallstack, item.iItem, 2, va("%d", entry->mLineNumber ) );
+		ListView_SetItemText ( mWndCallstack, item.iItem, 3, (LPSTR)entry->mFilename.c_str() );
+	}
+}
+
+void rvDebuggerWindow::UpdateScriptList(void)
+{
+	LVITEM item;
+	ListView_DeleteAllItems(mWndScriptList);
+	ZeroMemory(&item, sizeof(item));
+	item.mask = LVIF_TEXT | LVIF_IMAGE;
+
+	idStrList& scripts = mClient->GetServerScripts();
+	for (int i = 0; i < scripts.Num(); i++)
+	{
+		item.iItem = ListView_GetItemCount(mWndScriptList);
+		item.pszText = "";
+		//find in activeScripts
+		item.iImage = 0;
+		for (int j = 0; j < mScripts.Num(); j++)
+		{
+			if (!idStr::Icmp(mScripts[j]->GetFilename(), scripts[i]))
+			{
+				item.iImage = 1;
+				break;
+			}
+		}
+		ListView_InsertItem(mWndScriptList, &item);
+		ListView_SetItemText(mWndScriptList, item.iItem, 1, (LPSTR)scripts[i].c_str());
+	}
+}
+
+
+void rvDebuggerWindow::UpdateBreakpointList( void )
+{
+	LVITEM item;
+	ListView_DeleteAllItems( mWndBreakList );
+	ZeroMemory( &item, sizeof( item ) );
+	item.mask = LVIF_TEXT | LVIF_IMAGE;
+
+	int numBreakPoints = mClient->GetBreakpointCount();
+	for ( int i = 0; i < numBreakPoints; i++ )
+	{
+		rvDebuggerBreakpoint* bp = mClient->GetBreakpoint( i );
+		item.iItem = ListView_GetItemCount( mWndBreakList );
+		item.pszText = "";
+		item.iImage = 2; // breakpoint
+		ListView_InsertItem( mWndBreakList, &item );
+		
+		idStr lineStr( bp->GetLineNumber() );
+		ListView_SetItemText( mWndBreakList, item.iItem, 1, (LPSTR)bp->GetFilename() );
+		ListView_SetItemText( mWndBreakList, item.iItem, 2, (LPSTR)lineStr.c_str() );
+	}
+}
+
+/*
+================
+rvDebuggerWindow::UpdateWatch
+
+Updates the contents of the watch window
+================
+*/
+void rvDebuggerWindow::UpdateWatch ( void )
+{
+	int i;
+
+	// Inspect all the variables we are watching
+	for ( i = 0; i < mWatches.Num(); i ++ )
+	{
+		mWatches[i]->mModified = false;
+		mClient->InspectVariable ( mWatches[i]->mVariable, mCurrentStackDepth );
+	}
+
+	InvalidateRect ( mWndWatch, NULL, FALSE );
+	UpdateWindow ( mWndWatch );
+}
+
+/*
+================
+rvDebuggerWindow::HandleInitMenu
+
+Handles the initialization of the main menu
+================
+*/
+int rvDebuggerWindow::HandleInitMenu ( WPARAM wParam, LPARAM lParam )
+{
+	int		cMenuItems = GetMenuItemCount((HMENU)wParam);
+	int		nPos;
+	int		id;
+	UINT	flags;
+	HMENU	hmenu;
+
+	hmenu = (HMENU) wParam;
+
+	// Run through all the menu items in the menu and see if any of them need
+	// modification in any way
+	for (nPos = 0; nPos < cMenuItems; nPos++)
+	{
+		id    = GetMenuItemID(hmenu, nPos);
+		flags = 0;
+
+		// Handle popup menus too
+		if ( id < 0 )
+		{
+			HMENU sub = GetSubMenu ( hmenu, nPos );
+			if ( sub )
+			{
+				HandleInitMenu ( (WPARAM) sub, 0 );
+				continue;
+			}
+		}
+
+		// Handle the dynamic menu items specially
+		if ( id >= ID_DBG_WINDOWMIN && id <= ID_DBG_WINDOWMAX )
+		{
+			if ( id - ID_DBG_WINDOWMIN == mActiveScript )
+			{
+				CheckMenuItem ( hmenu, nPos, MF_BYPOSITION|MF_CHECKED );
+			}
+			else
+			{
+				CheckMenuItem ( hmenu, nPos, MF_BYPOSITION|MF_UNCHECKED );
+			}
+			continue;
+		}
+
+		// Menu items that are completely unrelated to the workspace
+		switch ( id )
+		{
+			case ID_DBG_DEBUG_RUN:
+			{
+				MENUITEMINFO info;
+				idStr		 run;
+
+				info.cbSize = sizeof(info);
+				info.fMask = MIIM_TYPE|MIIM_STATE;
+				info.fType = MFT_STRING;
+
+				if ( !mClient->IsConnected() )
+				{
+					run = "Run";
+					info.fState = MFS_ENABLED;
+				}
+				else
+				{
+					run = "Continue";
+					info.fState = mClient->IsStopped()?MFS_ENABLED:MFS_GRAYED;
+				}
+
+				info.dwTypeData = (LPSTR)run.c_str();
+				info.cch = run.Length ( );
+
+				SendMessage ( mWndToolbar, TB_ENABLEBUTTON, id, MAKELONG(((info.fState==MFS_ENABLED) ? TRUE : FALSE), 0) );
+
+				SetMenuItemInfo ( hmenu, id, FALSE, &info );
+
+				break;
+			}
+
+			case ID_DBG_DEBUG_BREAK:
+				if ( !mClient->IsConnected() || mClient->IsStopped() )
+				{
+					EnableMenuItem ( hmenu, nPos, MF_GRAYED|MF_BYPOSITION);
+					SendMessage ( mWndToolbar, TB_ENABLEBUTTON, id, MAKELONG(FALSE,0) );
+				}
+				else
+				{
+					EnableMenuItem ( hmenu, nPos, MF_ENABLED|MF_BYPOSITION);
+					SendMessage ( mWndToolbar, TB_ENABLEBUTTON, id, MAKELONG(TRUE,0) );
+				}
+				break;
+
+			case ID_DBG_DEBUG_RUNTOCURSOR:
+			case ID_DBG_DEBUG_STEPOUT:
+			case ID_DBG_DEBUG_STEPOVER:
+			case ID_DBG_DEBUG_STEPINTO:
+			case ID_DBG_DEBUG_SHOWNEXTSTATEMENT:
+			case ID_DBG_DEBUG_QUICKWATCH:
+				if ( !mClient->IsConnected() || !mClient->IsStopped() )
+				{
+					EnableMenuItem ( hmenu, nPos, MF_GRAYED|MF_BYPOSITION );
+					SendMessage ( mWndToolbar, TB_ENABLEBUTTON, id, MAKELONG(FALSE,0) );
+				}
+				else
+				{
+					EnableMenuItem ( hmenu, nPos, MF_ENABLED|MF_BYPOSITION );
+					SendMessage ( mWndToolbar, TB_ENABLEBUTTON, id, MAKELONG(TRUE,0) );
+				}
+				break;
+
+			case ID_DBG_WINDOW_CLOSEALL:
+			case ID_DBG_FILE_CLOSE:
+			case ID_DBG_DEBUG_TOGGLEBREAKPOINT:
+			case ID_DBG_EDIT_FIND:
+				EnableMenuItem ( hmenu, nPos, (mScripts.Num()?MF_ENABLED:MF_GRAYED)|MF_BYPOSITION);
+				break;
+		}
+	}
+
+	return 0;
+}
+
+
+void rvDebuggerWindow::ResizeImageList(int& widthOut, int& heightOut)
+{
+	//mTmpImageList
+	float scaling_factor = Win_GetWindowScalingFactor(mWnd);
+	int s16 = int(16 * scaling_factor);
+
+	TEXTMETRIC	tm;
+	HDC			dc;
+	dc = GetDC(mWndScript);
+
+	GetTextMetrics(dc, &tm);
+	int height = mZoomScaleDem ? (tm.tmHeight * (float)mZoomScaleNum / (float)mZoomScaleDem)  : tm.tmHeight ;
+	height *= scaling_factor;
+	int width = mZoomScaleDem ? ( tm.tmMaxCharWidth * (float)mZoomScaleNum / (float)mZoomScaleDem) : tm.tmMaxCharWidth;
+	width *= scaling_factor;
+
+	ImageList_Destroy(mTmpImageList);
+	mTmpImageList = ImageList_Create(width, height, ILC_COLOR | ILC_MASK , 0, 2);
+	ImageList_AddIcon(mTmpImageList, (HICON)LoadImage(mInstance, MAKEINTRESOURCE(IDI_DBG_EMPTY), IMAGE_ICON, width, height, LR_DEFAULTSIZE | LR_DEFAULTCOLOR));
+	ImageList_AddIcon(mTmpImageList, (HICON)LoadImage(mInstance, MAKEINTRESOURCE(IDI_DBG_CURRENT), IMAGE_ICON, width, height, LR_DEFAULTSIZE | LR_DEFAULTCOLOR));
+	ImageList_AddIcon(mTmpImageList, (HICON)LoadImage(mInstance, MAKEINTRESOURCE(IDI_DBG_BREAKPOINT), IMAGE_ICON, width, height, LR_DEFAULTSIZE | LR_DEFAULTCOLOR));
+	ImageList_AddIcon(mTmpImageList, (HICON)LoadImage(mInstance, MAKEINTRESOURCE(IDI_DBG_CURRENTLINE), IMAGE_ICON, width, height, LR_DEFAULTSIZE | LR_DEFAULTCOLOR));
+
+	widthOut = width;
+	heightOut = height;
+}
+
+float rvDebuggerWindow::GetMarginWidth ( void )
+{
+	TEXTMETRIC	tm;
+	HDC			dc;
+
+	dc = GetDC( mWndScript );
+	GetTextMetrics( dc, &tm );
+
+	float scaling_factor = Win_GetWindowScalingFactor( mWndScript );
+
+	return scaling_factor * (4 * tm.tmMaxCharWidth + tm.tmMaxCharWidth);
+}
+/*
+================
+rvDebuggerWindow::HandleCreate
+
+Handles the WM_CREATE command
+================
+*/
+int rvDebuggerWindow::HandleCreate ( WPARAM wparam, LPARAM lparam )
+{
+	UINT		tabsize = 16;
+	TEXTMETRIC	tm;
+	HDC			dc;
+	LOGFONT		lf;
+	int			i;
+
+	gDebuggerApp.GetOptions().GetWindowPlacement ( "wp_main", mWnd );
+
+	// Create the main toolbar
+	CreateToolbar ( );
+
+	// Create the script window
+	LoadLibrary ( "Riched20.dll" );
+	mWndScript = CreateWindow ( "RichEdit20A", "", WS_CHILD|WS_BORDER|ES_NOHIDESEL|ES_READONLY|ES_MULTILINE|ES_WANTRETURN|ES_AUTOVSCROLL|ES_AUTOHSCROLL|WS_VSCROLL|WS_HSCROLL, 0, 0, 100, 100, mWnd, (HMENU) IDC_DBG_SCRIPT, mInstance, 0 );
+	SendMessage ( mWndScript, EM_SETEVENTMASK, 0, ENM_SCROLL | ENM_CHANGE | ENM_UPDATE | ENM_SCROLLEVENTS | ENM_REQUESTRESIZE) ;
+	SendMessage ( mWndScript, EM_SETWORDBREAKPROC, 0, (LPARAM) ScriptWordBreakProc );
+	mOldScriptProc = (WNDPROC)GetWindowLongPtr ( mWndScript, GWLP_WNDPROC );
+	SetWindowLongPtr ( mWndScript, GWLP_USERDATA, (LONG_PTR)this );
+	SetWindowLongPtr ( mWndScript, GWLP_WNDPROC, (LONG_PTR)ScriptWndProc );
+
+	SendMessage ( mWndScript, EM_SETTABSTOPS, 1, (LPARAM)&tabsize );
+
+	dc = GetDC ( mWndScript );
+	GetTextMetrics ( dc, &tm );
+	ZeroMemory ( &lf, sizeof(lf) );
+	lf.lfHeight = tm.tmHeight * Win_GetWindowScalingFactor( mWndScript );
+	strcpy ( lf.lfFaceName, "Courier New" );
+
+	SendMessage ( mWndScript, WM_SETFONT, (WPARAM)CreateFontIndirect ( &lf ), 0 );
+	SendMessage ( mWndScript, EM_SETMARGINS, EC_LEFTMARGIN|EC_RIGHTMARGIN, MAKELONG( GetMarginWidth(),10) );
+	SendMessage ( mWndScript, EM_SETBKGNDCOLOR, 0, GetSysColor ( COLOR_3DFACE ) );
+
+	mWndOutput = CreateWindow ( "RichEdit20A", "", WS_CHILD|ES_READONLY|ES_MULTILINE|ES_WANTRETURN|ES_AUTOVSCROLL|ES_AUTOHSCROLL|WS_VSCROLL|WS_HSCROLL|WS_VISIBLE, 0, 0, 100, 100, mWnd, (HMENU) IDC_DBG_OUTPUT, mInstance, 0 );
+	SendMessage ( mWndOutput, WM_SETFONT, (WPARAM)CreateFontIndirect ( &lf ), 0 );
+	SendMessage ( mWndOutput, EM_SETMARGINS, EC_LEFTMARGIN|EC_RIGHTMARGIN, MAKELONG(18,10) );
+	SendMessage ( mWndOutput, EM_SETBKGNDCOLOR, 0, GetSysColor ( COLOR_3DFACE ) );
+	SendMessage ( mWndOutput, EM_SETEVENTMASK, 0, ENM_SCROLL | ENM_CHANGE | ENM_UPDATE | ENM_SCROLLEVENTS);
+
+	mWndConsole = CreateWindow ( "RichEdit20A", "", WS_CHILD|ES_READONLY|ES_MULTILINE|ES_WANTRETURN|ES_AUTOVSCROLL|ES_AUTOHSCROLL|WS_VSCROLL|WS_HSCROLL, 0, 0, 100, 100, mWnd, (HMENU) IDC_DBG_CONSOLE, mInstance, 0 );
+	SendMessage ( mWndConsole, WM_SETFONT, (WPARAM)CreateFontIndirect ( &lf ), 0 );
+	SendMessage ( mWndConsole, EM_SETMARGINS, EC_LEFTMARGIN|EC_RIGHTMARGIN, MAKELONG(18,10) );
+	SendMessage ( mWndConsole, EM_SETBKGNDCOLOR, 0, GetSysColor ( COLOR_3DFACE ) );
+
+	mWndConsoleInput = CreateWindow( "RichEdit20A", "", WS_CHILD | ES_WANTRETURN | ES_AUTOVSCROLL |  WS_VSCROLL | WS_BORDER, 0, 0, 100, 18, mWnd, ( HMENU ) IDC_DBG_CONSOLEINPUT, mInstance, 0 );
+	lf.lfHeight = -MulDiv( 8, GetDeviceCaps( dc, LOGPIXELSY ), 72 );
+	strcpy( lf.lfFaceName, "Arial" );
+	SendMessage( mWndConsoleInput, WM_SETFONT, ( WPARAM ) CreateFontIndirect( &lf ), 0 );
+	SendMessage( mWndConsoleInput, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG( 18, 10 ) );
+
+	mWndMargin = CreateWindow ( "STATIC", "", WS_VISIBLE|WS_CHILD, 0, 0, 0, 0, mWndScript, (HMENU)IDC_DBG_SPLITTER, mInstance, NULL );
+	SetWindowLongPtr ( mWndMargin, GWLP_USERDATA, (LONG_PTR)this );
+	SetWindowLongPtr ( mWndMargin, GWLP_WNDPROC, (LONG_PTR)MarginWndProc );
+
+	mWndBorder = CreateWindow ( "STATIC", "", WS_VISIBLE|WS_CHILD|SS_GRAYFRAME, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_BORDER, mInstance, NULL );
+
+	GetClientRect ( mWnd, &mSplitterRect );
+	mSplitterRect.top = (mSplitterRect.bottom-mSplitterRect.top) / 2;
+	mSplitterRect.bottom = mSplitterRect.top + 4;
+
+	mWndTabs = CreateWindow ( WC_TABCONTROL, "", TCS_BOTTOM|WS_CHILD|WS_VISIBLE|TCS_FOCUSNEVER, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_TABS, mInstance, NULL );
+	lf.lfHeight = -MulDiv(8, GetDeviceCaps(dc, LOGPIXELSY), 72);
+	strcpy ( lf.lfFaceName, "Arial" );
+	SendMessage ( mWndTabs, WM_SETFONT, (WPARAM)CreateFontIndirect ( &lf ), 0 );
+	ReleaseDC ( mWndScript, dc );
+
+	TCITEM item;
+	item.mask = TCIF_TEXT;
+	item.pszText = "Output";
+	TabCtrl_InsertItem ( mWndTabs, 0, &item );
+	item.pszText = "Console";
+	TabCtrl_InsertItem ( mWndTabs, 1, &item );
+	item.pszText = "Call Stack";
+	TabCtrl_InsertItem ( mWndTabs, 2, &item );
+	item.pszText = "Watch";
+	TabCtrl_InsertItem ( mWndTabs, 3, &item );
+	item.pszText = "Threads";
+	TabCtrl_InsertItem ( mWndTabs, 4, &item );
+	item.pszText = "Scripts";
+	TabCtrl_InsertItem ( mWndTabs, 5, &item );
+	item.pszText = "Breakpoints";
+	TabCtrl_InsertItem ( mWndTabs, 6, &item );
+
+	mWndCallstack = CreateWindow ( WC_LISTVIEW, "", LVS_REPORT|WS_CHILD|LVS_SHAREIMAGELISTS, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_CALLSTACK, mInstance, NULL );
+	mWndWatch     = CreateWindow ( WC_LISTVIEW, "", LVS_REPORT|WS_CHILD|LVS_EDITLABELS|LVS_OWNERDRAWFIXED, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_WATCH, mInstance, NULL );
+	mWndThreads   = CreateWindow ( WC_LISTVIEW, "", LVS_REPORT|WS_CHILD|LVS_SHAREIMAGELISTS, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_THREADS, mInstance, NULL );
+	mWndScriptList = CreateWindow( WC_LISTVIEW, "", LVS_REPORT|WS_CHILD|LVS_SHAREIMAGELISTS, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_SCRIPTLIST, mInstance, NULL );
+	mWndBreakList =  CreateWindow( WC_LISTVIEW, "", LVS_REPORT|WS_CHILD|LVS_SHAREIMAGELISTS, 0, 0, 0, 0, mWnd, (HMENU)IDC_DBG_BREAKLIST, mInstance, NULL );
+
+	LVCOLUMN col;
+	col.mask = LVCF_WIDTH|LVCF_TEXT;
+
+	col.cx = 20;
+	col.pszText = "";
+	ListView_InsertColumn( mWndBreakList, 0, &col );
+#if 0 // TODO: figure out how to get the function name in UpdateBreakpointList()
+	col.cx = 150;
+	col.pszText = "Function";
+	ListView_InsertColumn( mWndBreakList, 1, &col );
+#endif
+	col.cx = 350;
+	col.pszText = "Filename";
+	ListView_InsertColumn( mWndBreakList, 1, &col );
+	col.cx = 50;
+	col.pszText = "Line";
+	ListView_InsertColumn( mWndBreakList, 2, &col );
+
+	col.cx = 20;
+	col.pszText = "";
+	ListView_InsertColumn ( mWndScriptList, 0, &col);
+	col.cx = 350;
+	col.pszText = "Filename";
+	ListView_InsertColumn ( mWndScriptList, 1, &col );
+
+	col.cx = 20;
+	col.pszText = "";
+	ListView_InsertColumn ( mWndCallstack, 0, &col );
+	col.cx = 150;
+	col.pszText = "Function";
+	ListView_InsertColumn ( mWndCallstack, 1, &col );
+	col.cx = 50;
+	col.pszText = "Line";
+	ListView_InsertColumn ( mWndCallstack, 2, &col );
+	col.cx = 350;
+	col.pszText = "Filename";
+	ListView_InsertColumn ( mWndCallstack, 3, &col );
+
+	col.cx = 20;
+	col.pszText = "";
+	ListView_InsertColumn ( mWndThreads, 0, &col );
+	col.cx = 25;
+	col.pszText = "ID";
+	ListView_InsertColumn ( mWndThreads, 1, &col );
+	col.cx = 150;
+	col.pszText = "Name";
+	ListView_InsertColumn ( mWndThreads, 2, &col );
+	col.cx = 100;
+	col.pszText = "State";
+	ListView_InsertColumn ( mWndThreads, 3, &col );
+
+	col.cx = 150;
+	col.pszText = "Name";
+	ListView_InsertColumn ( mWndWatch, 0, &col );
+	col.cx = 200;
+	col.pszText = "Value";
+	ListView_InsertColumn ( mWndWatch, 1, &col );
+
+	// Create the image list that is used by the threads window, callstack window, and
+	// margin window
+	mImageList = ImageList_Create ( 16, 16, ILC_COLOR|ILC_MASK, 0, 2 );
+	ImageList_AddIcon ( mImageList, (HICON)LoadImage ( mInstance, MAKEINTRESOURCE(IDI_DBG_EMPTY), IMAGE_ICON, 16, 16, LR_DEFAULTSIZE|LR_DEFAULTCOLOR) );
+	ImageList_AddIcon ( mImageList, (HICON)LoadImage ( mInstance, MAKEINTRESOURCE(IDI_DBG_CURRENT), IMAGE_ICON, 16, 16, LR_DEFAULTSIZE|LR_DEFAULTCOLOR) );
+	ImageList_AddIcon ( mImageList, (HICON)LoadImage ( mInstance, MAKEINTRESOURCE(IDI_DBG_BREAKPOINT), IMAGE_ICON, 16, 16, LR_DEFAULTSIZE|LR_DEFAULTCOLOR) );
+	ImageList_AddIcon ( mImageList, (HICON)LoadImage ( mInstance, MAKEINTRESOURCE(IDI_DBG_CURRENTLINE), IMAGE_ICON, 16, 16, LR_DEFAULTSIZE|LR_DEFAULTCOLOR) );
+	
+	int w, h;
+	ResizeImageList(w, h);
+	ListView_SetImageList ( mWndScriptList, mTmpImageList, LVSIL_SMALL );
+	ListView_SetImageList ( mWndThreads, mImageList, LVSIL_SMALL );
+	ListView_SetImageList ( mWndCallstack, mImageList, LVSIL_SMALL );
+	ListView_SetImageList ( mWndBreakList, mImageList, LVSIL_SMALL );
+
+	EnableWindows ( FALSE );
+	EnableWindow ( mWndScriptList, true );
+	
+	ListView_SetExtendedListViewStyle ( mWndCallstack, LVS_EX_FULLROWSELECT );
+	ListView_SetExtendedListViewStyle ( mWndThreads, LVS_EX_FULLROWSELECT );
+	ListView_SetExtendedListViewStyle ( mWndScriptList, LVS_EX_FULLROWSELECT );
+	ListView_SetExtendedListViewStyle ( mWndBreakList, LVS_EX_FULLROWSELECT );
+
+	gDebuggerApp.GetOptions().GetColumnWidths ( "cw_callstack", mWndCallstack );
+	gDebuggerApp.GetOptions().GetColumnWidths ( "cw_threads", mWndThreads );
+	gDebuggerApp.GetOptions().GetColumnWidths ( "cw_watch", mWndWatch );
+
+	mWndToolTips = CreateWindowEx ( WS_EX_TOPMOST,
+									TOOLTIPS_CLASS,
+									NULL,
+									WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
+									CW_USEDEFAULT,
+									CW_USEDEFAULT,
+									CW_USEDEFAULT,
+									CW_USEDEFAULT,
+									mWnd,
+									NULL,
+									mInstance,
+									NULL
+									);
+
+	SendMessage ( mWndToolTips, TTM_SETDELAYTIME, TTDT_INITIAL, MAKELONG(400,0) );
+	SendMessage ( mWndToolTips, TTM_SETDELAYTIME, TTDT_RESHOW, MAKELONG(400,0) );
+
+	SetWindowPos( mWndToolTips, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
+	LVITEM lvItem;
+	lvItem.iItem = 0;
+	lvItem.iSubItem = 0;
+	lvItem.mask = LVIF_TEXT;
+	lvItem.pszText = "";
+	ListView_InsertItem ( mWndWatch, &lvItem );
+	ListView_SetExtendedListViewStyle ( mWndWatch, LVS_EX_FULLROWSELECT );
+
+	// Recent files
+	InitRecentFiles ( );
+	UpdateRecentFiles ( );
+
+	HandleInitMenu ( (WPARAM)GetMenu ( mWnd ), 0 );
+
+	// Read in the watches
+	for ( i = 0; ; i ++ )
+	{
+		const char* s = gDebuggerApp.GetOptions().GetString ( va("watch%d", i ) );
+		if ( !s || !s[0] )
+		{
+			break;
+		}
+
+		AddWatch ( s );
+	}
+
+	RECT t;
+	GetClientRect(mWndScript, &t);
+	SendMessage(mWndScript, WM_SIZE, 0, MAKELPARAM(t.right - t.left, t.bottom - t.top));
+
+	return 0;
+}
+
+/*
+================
+rvDebuggerWindow::HandleCommand
+
+Handles the WM_COMMAND message for this window
+================
+*/
+int rvDebuggerWindow::HandleCommand ( WPARAM wparam, LPARAM lparam )
+{
+	int event = HIWORD(wparam);
+	int id    = LOWORD(wparam);
+
+	// The window menu list needs to be handled specially
+	if ( id >= ID_DBG_WINDOWMIN && id <= ID_DBG_WINDOWMAX )
+	{
+		mActiveScript = id - ID_DBG_WINDOWMIN;
+		UpdateScript ( );
+		return 0;
+	}
+
+	// The recent file list needs to be handled specially
+	if ( LOWORD(wparam) >= ID_DBG_FILE_MRU1 && LOWORD(wparam) < ID_DBG_FILE_MRU1 + rvRegistryOptions::MAX_MRU_SIZE )
+	{
+		idStr filename;
+		filename = gDebuggerApp.GetOptions().GetRecentFile ( gDebuggerApp.GetOptions().GetRecentFileCount() - (LOWORD(wparam)-ID_DBG_FILE_MRU1) - 1 );
+		if ( !OpenScript ( filename ) )
+		{
+			MessageBox ( mWnd, va("Failed to open script '%s'", filename.c_str() ), "Quake 4 Script Debugger", MB_OK );
+		}
+		return 0;
+	}
+
+	switch ( id )
+	{
+		case ID_DBG_SEND_COMMAND:
+		{
+			if ( mClient->IsConnected( ) && GetFocus( ) == mWndConsoleInput ) {
+				GETTEXTLENGTHEX textLen;
+				int				chars;
+				textLen.flags = GTL_DEFAULT | GTL_USECRLF;
+				textLen.codepage = CP_ACP;
+				chars = SendMessage( mWndConsoleInput, EM_GETTEXTLENGTHEX, ( WPARAM ) &textLen, 0 );
+
+				char *text = new char[chars + 1];
+
+				GETTEXTEX getText;
+				getText.cb = chars + 1;
+				getText.codepage = CP_ACP;
+				getText.flags = GT_DEFAULT | GT_USECRLF;
+				getText.lpDefaultChar = NULL;
+				getText.lpUsedDefChar = NULL;
+				SendMessage( mWndConsoleInput, EM_GETTEXTEX, ( WPARAM ) &getText, ( LPARAM ) text );
+				idStr parse = text;
+				delete[] text;
+
+				mClient->SendCommand( parse.c_str() );
+
+				SendMessage( mWndConsoleInput, EM_SETSEL, 0, -1 );
+				SendMessage( mWndConsoleInput, EM_REPLACESEL, FALSE, ( LPARAM ) "" );
+				UpdateWindow( mWndConsoleInput );
+			}
+			break;
+		}
+
+		case ID_DBG_EDIT_FINDSELECTED:
+		{
+			idStr text;
+			GetSelectedText ( text );
+			FindNext ( text );
+			break;
+		}
+
+		case ID_DBG_EDIT_FINDSELECTEDPREV:
+		{
+			idStr text;
+			GetSelectedText ( text );
+			FindPrev ( text );
+			break;
+		}
+
+		case ID_DBG_EDIT_FINDNEXT:
+			FindNext ( );
+			break;
+
+		case ID_DBG_EDIT_FINDPREV:
+			FindPrev ( );
+			break;
+
+		case ID_DBG_DEBUG_QUICKWATCH:
+		{
+			idStr text;
+
+			GetSelectedText ( text );
+			rvDebuggerQuickWatchDlg dlg;
+			dlg.DoModal ( this, mCurrentStackDepth, text );
+			break;
+		}
+
+		case ID_DBG_HELP_ABOUT:
+			DialogBox ( mInstance, MAKEINTRESOURCE(IDD_DBG_ABOUT), mWnd, AboutDlgProc );
+			break;
+
+		case ID_DBG_DEBUG_BREAK:
+			mClient->Break ( );
+			break;
+
+		case ID_DBG_DEBUG_STEPOVER:
+			EnableWindows ( FALSE );
+			mClient->StepOver ( );
+			break;
+
+		case ID_DBG_DEBUG_STEPINTO:
+			EnableWindows ( FALSE );
+			mClient->StepInto ( );
+			break;
+
+		case ID_DBG_DEBUG_RUN:
+			// Run the game if its not running
+			if ( !mClient->IsConnected ( ) )
+			{
+				char exeFile[MAX_PATH];
+				char curDir[MAX_PATH];
+
+				STARTUPINFO			startup;
+				PROCESS_INFORMATION	process;
+
+				ZeroMemory ( &startup, sizeof(startup) );
+				startup.cb = sizeof(startup);
+
+				GetCurrentDirectory ( MAX_PATH, curDir );
+
+				GetModuleFileName ( NULL, exeFile, MAX_PATH );
+				const char* s = va("%s +set fs_game %s +set fs_cdpath %s +set com_enableDebuggerServer 1", exeFile, cvarSystem->GetCVarString( "fs_game" ), cvarSystem->GetCVarString( "fs_cdpath" ) );
+				CreateProcess ( NULL, (LPSTR)s,
+				NULL, NULL, FALSE, 0, NULL, curDir, &startup, &process );
+
+				CloseHandle ( process.hThread );
+				CloseHandle ( process.hProcess );
+			}
+			else if ( mClient->IsStopped() )
+			{
+				EnableWindows ( FALSE );
+				mClient->Resume ( );
+				UpdateToolbar ( );
+				UpdateTitle ( );
+				InvalidateRect ( mWnd, NULL, FALSE );
+			}
+
+			break;
+
+		case IDC_DBG_SCRIPT:
+		{
+			RECT	t;
+			LONG	num;
+			LONG	dem;
+
+			SendMessage ( mWndScript, EM_GETZOOM, (WPARAM)&num, (LPARAM)&dem );
+			if ( num != mZoomScaleNum || dem != mZoomScaleDem )
+			{
+				mZoomScaleNum = num;
+				mZoomScaleDem = dem;
+				GetClientRect ( mWndScript, &t );
+				SendMessage ( mWndScript, WM_SIZE, 0, MAKELPARAM(t.right-t.left ,t.bottom-t.top) );
+			}
+			else
+			{
+				InvalidateRect ( mWndMargin, NULL, TRUE );
+			}
+			break;
+		}
+
+		case 111: // DG: Debugger.rc has 'MENUITEM "Toggle &Breakpoint\tF9", 111' for the context menu no idea why 111 but this works
+		case ID_DBG_DEBUG_TOGGLEBREAKPOINT:
+			ToggleBreakpoint ( );
+			break;
+
+		case ID_DBG_FILE_EXIT:
+			PostMessage ( mWnd, WM_CLOSE, 0, 0 );
+			break;
+
+		case ID_DBG_FILE_CLOSE:
+			if ( mScripts.Num() )
+			{
+				delete mScripts[mActiveScript];
+				mScripts.RemoveIndex ( mActiveScript );
+				if ( mActiveScript >= mScripts.Num ( ) )
+				{
+					mActiveScript --;
+				}
+				UpdateWindowMenu ( );
+				UpdateScript ( );
+			}
+			break;
+
+		case ID_DBG_FILE_NEXT:
+			if ( mScripts.Num ( ) > 0 )
+			{
+				mActiveScript++;
+				if ( mActiveScript >= mScripts.Num ( ) )
+				{
+					mActiveScript = 0;
+				}
+				UpdateWindowMenu ( );
+				UpdateScript ( );
+			}
+			break;
+
+		case ID_DBG_FILE_OPEN:
+		{
+			rvOpenFileDialog dlg;
+			dlg.SetTitle ( "Open Script" );
+			dlg.SetFilter ( "*.script; *.gui; *.state" );
+			dlg.SetFlags ( OFD_MUSTEXIST );
+			if ( dlg.DoModal ( mWnd ) )
+			{
+				if ( !OpenScript ( dlg.GetFilename ( ) ) )
+				{
+					MessageBox ( mWnd, va("Failed to open script '%s'",dlg.GetFilename ( )), "Quake 4 Script Debugger", MB_OK );
+				}
+			}
+			break;
+		}
+
+		case ID_DBG_EDIT_FIND:
+		{
+			rvDebuggerFindDlg dlg;
+			if ( dlg.DoModal ( this ) )
+			{
+				FindNext ( dlg.GetFindText ( ) );
+			}
+			break;
+		}
+
+		case ID_DBG_WINDOW_CLOSEALL:
+		{
+			for ( int i = 0; i < mScripts.Num(); i ++ )
+			{
+				delete mScripts[i];
+			}
+
+			mScripts.Clear ( );
+			mActiveScript = -1;
+
+			UpdateWindowMenu ( );
+			UpdateScript ( );
+			break;
+		}
+
+		// DG: support "Run To Cursor" from context menu
+		case ID_DBG_DEBUG_RUNTOCURSOR:
+		{
+			// Find the currently selected line
+			DWORD sel;
+			SendMessage( mWndScript, EM_GETSEL, (WPARAM)&sel, 0 );
+			int lineNumber = SendMessage( mWndScript, EM_LINEFROMCHAR, sel, 0 ) + 1;
+
+			const char* filename = mScripts[mActiveScript]->GetFilename();
+			mClient->AddBreakpoint( filename, lineNumber, true );
+			mClient->Resume();
+			break;
+		}
+
+		// TODO: case ID_DBG_DEBUG_SHOWNEXTSTATEMENT:
+		//       whatever this is supposed to do (also from context menu)
+	}
+
+	return 0;
+}
+
+/*
+================
+rvDebuggerWindow::WndProc
+
+Window procedure for the deubgger window
+================
+*/
+LRESULT CALLBACK rvDebuggerWindow::WndProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+	rvDebuggerWindow* window = (rvDebuggerWindow*) GetWindowLongPtr ( wnd, GWLP_USERDATA );
+
+	switch ( msg )
+	{
+		case WM_INITMENUPOPUP:
+			window->HandleInitMenu ( wparam, lparam );
+			break;
+
+		case WM_DESTROY:
+		{
+			gDebuggerApp.GetOptions().SetColumnWidths ( "cw_callstack", window->mWndCallstack );
+			gDebuggerApp.GetOptions().SetColumnWidths ( "cw_threads", window->mWndThreads );
+			gDebuggerApp.GetOptions().SetColumnWidths ( "cw_watch", window->mWndWatch );
+			gDebuggerApp.GetOptions().SetWindowPlacement ( "wp_main", wnd );
+
+			int i;
+			for ( i = 0; i < window->mWatches.Num ( ); i ++ )
+			{
+				gDebuggerApp.GetOptions().SetString ( va("watch%d", i ), window->mWatches[i]->mVariable );
+			}
+			gDebuggerApp.GetOptions().SetString ( va("watch%d", i ), "" );
+
+			window->mWnd = NULL;
+			SetWindowLongPtr ( wnd, GWLP_USERDATA, 0 );
+			break;
+		}
+
+		case WM_ERASEBKGND:
+			return 0;
+
+		case WM_COMMAND:
+			window->HandleCommand ( wparam, lparam );
+			break;
+
+		case WM_SETCURSOR:
+		{
+			POINT point;
+			GetCursorPos ( &point );
+			ScreenToClient ( wnd, &point );
+			if ( PtInRect ( &window->mSplitterRect, point ) )
+			{
+				SetCursor ( LoadCursor ( NULL, IDC_SIZENS ) );
+				return true;
+			}
+			break;
+		}
+
+		case WM_SIZE:
+		{
+			float scaling_factor = Win_GetWindowScalingFactor(wnd);
+			int s18 = int(18 * scaling_factor);
+			int s4 = int(4 * scaling_factor);
+			int s10 = int(10 * scaling_factor);
+
+			RECT rect;
+			window->mMarginSize = window->mZoomScaleDem ? ((long)(s18 * (float)window->mZoomScaleNum / (float)window->mZoomScaleDem)): s18;
+			window->mSplitterRect.left = 0;
+			window->mSplitterRect.right = LOWORD(lparam);
+
+			SendMessage ( window->mWndToolbar, TB_AUTOSIZE, 0, 0 );
+			GetWindowRect ( window->mWndToolbar, &rect );
+			MoveWindow ( window->mWndScript, 0, rect.bottom-rect.top, LOWORD(lparam), window->mSplitterRect.top-(rect.bottom-rect.top), TRUE );
+			MoveWindow ( window->mWndMargin, 0, 0, window->mMarginSize, window->mSplitterRect.top-(rect.bottom-rect.top), TRUE );
+
+			SetRect ( &rect, 0, window->mSplitterRect.bottom, LOWORD(lparam), HIWORD(lparam) );
+			MoveWindow ( window->mWndTabs, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			SendMessage ( window->mWndTabs, TCM_ADJUSTRECT, FALSE, (LPARAM)&rect );
+			rect.bottom -= s4;
+			MoveWindow ( window->mWndBorder, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			InflateRect ( &rect, -1, -1 );
+			MoveWindow ( window->mWndOutput, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			MoveWindow ( window->mWndConsole, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top - s18, TRUE );
+			MoveWindow ( window->mWndConsoleInput, rect.left, rect.bottom-s18, rect.right - rect.left, s18, TRUE );
+			MoveWindow ( window->mWndCallstack, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			MoveWindow ( window->mWndWatch, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			MoveWindow ( window->mWndThreads, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			MoveWindow ( window->mWndScriptList, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+			MoveWindow ( window->mWndBreakList, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, TRUE );
+
+			// FIXME: was *2.25, increased for line numbers up to 9999; but neither works particularly well
+			//        if DPI scaling is involved, because script code text and linenumbers aren't DPI scaled
+			int lmargin = window->GetMarginWidth();
+			SendMessage(window->mWndScript, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG(lmargin, s10));
+			SendMessage(window->mWndCallstack, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG(s18, s10));
+			SendMessage(window->mWndOutput, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG(s18, s10));
+			SendMessage(window->mWndConsole, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG(s18, s10));
+			SendMessage( window->mWndConsoleInput, EM_SETMARGINS, EC_LEFTMARGIN | EC_RIGHTMARGIN, MAKELONG( s18, s10 ) );
+
+			break;
+		}
+
+		case WM_PAINT:
+		{
+			PAINTSTRUCT ps;
+			HDC dc = BeginPaint ( wnd, &ps );
+			FillRect ( dc, &window->mSplitterRect, GetSysColorBrush ( COLOR_3DFACE ) );
+
+			if ( !window->mScripts.Num() )
+			{
+				RECT rect;
+				GetClientRect ( wnd, &rect );
+				rect.bottom = window->mSplitterRect.top;
+				FillRect ( dc, &rect, GetSysColorBrush ( COLOR_APPWORKSPACE ) );
+			}
+
+			EndPaint ( wnd, &ps );
+			break;
+		}
+
+		case WM_LBUTTONDOWN:
+		{
+			POINT pt = { LOWORD(lparam),HIWORD(lparam) };
+			if ( PtInRect ( &window->mSplitterRect, pt ) )
+			{
+				window->mSplitterDrag = true;
+				SetCapture ( wnd );
+
+				HDC dc = GetDC ( wnd );
+				DrawFocusRect ( dc, &window->mSplitterRect );
+				ReleaseDC ( wnd, dc );
+			}
+			break;
+		}
+		case WM_MOUSEWHEEL:
+		{
+			HDC dc = GetDC(wnd);
+			DrawFocusRect(dc, &window->mSplitterRect);
+			ReleaseDC(wnd, dc);
+
+			RECT client;
+			GetClientRect(wnd, &client);
+			SendMessage(wnd, WM_SIZE, 0, MAKELPARAM(client.right - client.left, client.bottom - client.top));
+
+		}
+		case WM_LBUTTONUP:
+			if ( window->mSplitterDrag )
+			{
+				HDC dc = GetDC ( wnd );
+				DrawFocusRect ( dc, &window->mSplitterRect );
+				ReleaseDC ( wnd, dc );
+
+				window->mSplitterDrag = false;
+
+				RECT client;
+				GetClientRect ( wnd, &client );
+				SendMessage ( wnd, WM_SIZE, 0, MAKELPARAM(client.right-client.left,client.bottom-client.top) );
+
+				InvalidateRect ( wnd, NULL, TRUE );
+
+				ReleaseCapture ( );
+			}
+			break;
+
+		case WM_MOUSEMOVE:
+		{
+			if ( window->mSplitterDrag )
+			{
+				HDC dc = GetDC ( wnd );
+				DrawFocusRect ( dc, &window->mSplitterRect );
+				ReleaseDC ( wnd, dc );
+
+				if ( GetCapture ( ) != wnd )
+				{
+					break;
+				}
+
+				RECT client;
+				GetClientRect ( wnd, &client );
+
+				window->mSplitterRect.top = HIWORD(lparam);
+				if ( window->mSplitterRect.top < client.top )
+				{
+					window->mSplitterRect.top = client.top;
+				}
+				else if ( window->mSplitterRect.top + 4 > client.bottom )
+				{
+					window->mSplitterRect.top = client.bottom - 4;
+				}
+				window->mSplitterRect.bottom = window->mSplitterRect.top + 4;
+
+				dc = GetDC ( wnd );
+				DrawFocusRect ( dc, &window->mSplitterRect );
+				ReleaseDC ( wnd, dc );
+			}
+			break;
+		}
+
+		case WM_DRAWITEM:
+			window->HandleDrawItem ( wparam, lparam );
+			break;
+
+		case WM_CREATE:
+		{
+			CREATESTRUCT* cs = (CREATESTRUCT*) lparam;
+			window = (rvDebuggerWindow*) cs->lpCreateParams;
+			SetWindowLongPtr ( wnd, GWLP_USERDATA, (LONG_PTR)cs->lpCreateParams );
+
+			window->mWnd = wnd;
+			window->HandleCreate ( wparam, lparam );
+
+			break;
+		}
+
+		case WM_ACTIVATE:
+			window->HandleActivate ( wparam, lparam );
+			break;
+
+		case WM_NOTIFY:
+		{
+			NMHDR*	hdr;
+			hdr = (NMHDR*)lparam;
+
+			// Tool tips
+			if ( hdr->code == TTN_GETDISPINFO )
+			{
+				window->HandleTooltipGetDispInfo ( wparam, lparam );
+				break;
+			}
+
+			switch ( hdr->idFrom )
+			{
+				case IDC_DBG_WATCH:
+					switch ( hdr->code )
+					{
+						case LVN_KEYDOWN:
+						{
+							NMLVKEYDOWN* key = (NMLVKEYDOWN*) hdr;
+							switch ( key->wVKey )
+							{
+								case VK_DELETE:
+								{
+									int sel = ListView_GetNextItem ( hdr->hwndFrom, -1, LVNI_SELECTED );
+									if ( sel != -1 && sel != ListView_GetItemCount ( hdr->hwndFrom ) - 1 )
+									{
+										LVITEM item;
+										item.iItem = sel;
+										item.mask = LVIF_PARAM;
+										ListView_GetItem ( hdr->hwndFrom, &item );
+										ListView_DeleteItem ( hdr->hwndFrom, sel );
+
+										window->mWatches.Remove ( (rvDebuggerWatch*)item.lParam );
+										delete (rvDebuggerWatch*)item.lParam;
+
+										ListView_SetItemState ( hdr->hwndFrom,
+																sel,
+																LVIS_SELECTED, LVIS_SELECTED );
+
+										if ( ListView_GetNextItem ( hdr->hwndFrom, -1, LVNI_SELECTED ) == -1 )
+										{
+											ListView_SetItemState ( hdr->hwndFrom,
+																	ListView_GetItemCount ( hdr->hwndFrom ) - 1,
+																	LVIS_SELECTED, LVIS_SELECTED );
+										}
+									}
+									break;
+								}
+
+								case VK_RETURN:
+								{
+									int sel = ListView_GetNextItem ( hdr->hwndFrom, -1, LVNI_SELECTED );
+									if ( sel != -1 )
+									{
+										ListView_EditLabel ( hdr->hwndFrom, sel );
+									}
+									break;
+								}
+							}
+							break;
+						}
+
+						case LVN_BEGINLABELEDIT:
+						{
+							NMLVDISPINFO* di = (NMLVDISPINFO*)hdr;
+
+							DWORD style = GetWindowLong ( ListView_GetEditControl ( hdr->hwndFrom ), GWL_STYLE );
+							SetWindowLong ( ListView_GetEditControl ( hdr->hwndFrom ), GWL_STYLE, style & (~WS_BORDER) );
+
+							rvDebuggerWatch* watch = (rvDebuggerWatch*)di->item.lParam;
+							if ( watch )
+							{
+								SetWindowText ( ListView_GetEditControl ( hdr->hwndFrom ), watch->mVariable );
+							}
+
+							return FALSE;
+						}
+
+						case LVN_ENDLABELEDIT:
+						{
+							NMLVDISPINFO* di = (NMLVDISPINFO*)hdr;
+
+							if ( di->item.iItem == ListView_GetItemCount ( hdr->hwndFrom ) - 1 )
+							{
+								if ( !di->item.pszText || !di->item.pszText[0] )
+								{
+									return FALSE;
+								}
+
+								window->AddWatch ( ((NMLVDISPINFO*)hdr)->item.pszText );
+								window->UpdateWatch ( );
+								return FALSE;
+							}
+							else
+							{
+								rvDebuggerWatch* watch = (rvDebuggerWatch*) di->item.lParam;
+								if ( watch && di->item.pszText && di->item.pszText[0] )
+								{
+									watch->mVariable = di->item.pszText;
+								}
+							}
+
+							return TRUE;
+						}
+					}
+					break;
+				case IDC_DBG_CALLSTACK:
+					if ( hdr->code == NM_DBLCLK )
+					{
+						int sel = ListView_GetNextItem ( hdr->hwndFrom, -1, LVNI_SELECTED );
+						if ( sel != -1 )
+						{
+							window->mCurrentStackDepth = sel;
+							window->UpdateCallstack ( );
+							window->UpdateWatch ( );
+							window->OpenScript ( window->mClient->GetCallstack()[window->mCurrentStackDepth]->mFilename,
+												 window->mClient->GetCallstack()[window->mCurrentStackDepth]->mLineNumber );
+						}
+					}
+					break;
+				case IDC_DBG_SCRIPTLIST:
+					if ( hdr->code == NM_DBLCLK )
+					{
+						int sel = ListView_GetNextItem(hdr->hwndFrom, -1, LVNI_SELECTED);
+
+						if (sel != -1)
+						{
+							LVITEM item = { 0 }; 
+							char   temp[1024] = { 0 };
+							item.mask = LVIF_TEXT;
+							item.pszText = temp;
+							item.cchTextMax = sizeof(temp) - 1;
+							item.iSubItem = 1;
+							item.iItem = sel;
+
+							ListView_GetItem(hdr->hwndFrom, &item);
+
+							if (strlen(item.pszText) > 0)
+							{
+								window->OpenScript(item.pszText);
+								window->UpdateScriptList();
+							}
+						}
+					}
+					break;
+
+				case IDC_DBG_BREAKLIST:
+					if ( hdr->code == NM_DBLCLK || hdr->code == NM_CLICK ) {
+						LPNMITEMACTIVATE ia = (LPNMITEMACTIVATE)lparam;
+						int sel = ia->iItem;
+						if ( sel != -1 ) {
+							rvDebuggerBreakpoint* bp = window->mClient->GetBreakpoint( sel );
+							if ( bp != NULL ) {
+								if ( hdr->code == NM_DBLCLK ) {
+									// double clicked breakpoint => show it in its file
+									window->OpenScript( bp->GetFilename(), bp->GetLineNumber() - 1 );
+								} else if( ia->iSubItem == 0 ) {
+									// clicked breakpoint symbol => delete breakpoint
+									window->mClient->RemoveBreakpoint( bp->GetID() );
+									window->UpdateBreakpointList();
+								}
+							}
+						}
+					} else if ( hdr->code == LVN_KEYDOWN ) {
+						// when user selects a breakpoints and presses the Del key, remove the breakpoint
+						int sel = ListView_GetNextItem( hdr->hwndFrom, -1, LVNI_SELECTED );
+						if ( sel != -1 ) {
+							LPNMLVKEYDOWN kd = (LPNMLVKEYDOWN)lparam;
+							rvDebuggerBreakpoint* bp = window->mClient->GetBreakpoint( sel );
+							if ( kd->wVKey == VK_DELETE && bp != NULL ) {
+								window->mClient->RemoveBreakpoint( bp->GetID() );
+								window->UpdateBreakpointList();
+							}
+						}
+					}
+					break;
+
+				case IDC_DBG_TABS:
+					if ( hdr->code == TCN_SELCHANGE )
+					{
+						ShowWindow ( window->mWndOutput, SW_HIDE );
+						ShowWindow ( window->mWndConsole, SW_HIDE );
+						ShowWindow ( window->mWndConsoleInput, SW_HIDE );
+						ShowWindow ( window->mWndCallstack, SW_HIDE );
+						ShowWindow ( window->mWndWatch, SW_HIDE );
+						ShowWindow ( window->mWndThreads, SW_HIDE );
+						ShowWindow ( window->mWndScriptList, SW_HIDE );
+						ShowWindow ( window->mWndBreakList, SW_HIDE );
+						switch ( TabCtrl_GetCurSel ( hdr->hwndFrom ) )
+						{
+							case 0:
+								ShowWindow ( window->mWndOutput, SW_SHOW );
+								break;
+
+							case 1:
+								ShowWindow ( window->mWndConsole, SW_SHOW );
+								ShowWindow( window->mWndConsoleInput, SW_SHOW );
+								break;
+
+							case 2:
+								ShowWindow ( window->mWndCallstack, SW_SHOW );
+								break;
+
+							case 3:
+								ShowWindow ( window->mWndWatch, SW_SHOW );
+								break;
+
+							case 4:
+								ShowWindow ( window->mWndThreads, SW_SHOW );
+								break;
+
+							case 5:
+								ShowWindow(window->mWndScriptList, SW_SHOW);
+								break;
+
+							case 6:
+								ShowWindow( window->mWndBreakList, SW_SHOW );
+								break;
+						}
+					}
+					break;
+			}
+			break;
+		}
+
+		case WM_CLOSE:
+			if ( window->mClient->IsConnected ( ) )
+			{
+				if ( IDNO == MessageBox ( wnd, "The debugger is currently connected to a running version of the game.  Are you sure you want to close now?", "Dhewm3 Script Debugger", MB_YESNO|MB_ICONQUESTION ) )
+				{
+					return 0;
+				}
+			}
+			PostQuitMessage ( 0 );
+			break;
+	}
+
+	return DefWindowProc ( wnd, msg, wparam, lparam );
+}
+
+/*
+================
+rvDebuggerWindow::Activate
+
+Static method that will activate the currently running debugger.  If one is found
+and activated then true will be returned.
+================
+*/
+bool rvDebuggerWindow::Activate ( void )
+{
+	HWND find;
+
+	find = FindWindow ( DEBUGGERWINDOWCLASS, NULL );
+	if ( !find )
+	{
+		return false;
+	}
+
+	SetForegroundWindow ( find );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerWindow::ProcessNetMessage
+
+Process an incoming network message
+================
+*/
+void rvDebuggerWindow::ProcessNetMessage ( idBitMsg* msg )
+{
+	short command;
+
+	command = msg->ReadShort( );
+
+	switch ( command )
+	{
+		case DBMSG_REMOVEBREAKPOINT:
+			MessageBeep(MB_ICONEXCLAMATION);
+			InvalidateRect(mWndScript, NULL, FALSE);
+			UpdateBreakpointList();
+			break;
+
+		case DBMSG_RESUMED:
+			UpdateTitle ( );
+			UpdateToolbar ( );
+			break;
+
+		case DBMSG_INSPECTVARIABLE:
+		{
+			char temp[1024];
+			char temp2[1024];
+			int	 i;
+
+			msg->ReadShort ( );
+			msg->ReadString (  temp, 1024 );
+			msg->ReadString (  temp2, 1024 );
+			if ( mTooltipVar.Icmp ( temp ) == 0 )
+			{
+				mTooltipValue = temp2;
+
+				TOOLINFO info;
+				info.cbSize   = sizeof(info);
+				info.hwnd     = mWndScript;
+				info.uId      = 0;
+				info.hinst    = mInstance;
+				info.lpszText = va("%s=%s", mTooltipVar.c_str(), mTooltipValue.c_str() );
+				SendMessage ( mWndToolTips, TTM_UPDATETIPTEXT, 0, (LPARAM)&info );
+				SendMessage ( mWndToolTips, TTM_UPDATE, 0, 0 );
+			}
+
+			// See if any of the watches were updated by this inspect
+			for ( i = 0; i < mWatches.Num(); i ++ )
+			{
+				rvDebuggerWatch* watch = mWatches[i];
+
+				// See if the name matches the variable
+				if ( watch->mVariable.Cmp ( temp ) )
+				{
+					continue;
+				}
+
+				// Has the value changed?
+				if ( !watch->mValue.Cmp ( temp2 ) )
+				{
+					continue;
+				}
+
+				watch->mModified = true;
+				watch->mValue = temp2;
+
+				// Find the list view item that is storing this watch info and redraw it
+				for ( int l = 0; l < ListView_GetItemCount(mWndWatch); l ++ )
+				{
+					LVITEM item;
+					item.mask = LVIF_PARAM;
+					item.iItem = l;
+					ListView_GetItem ( mWndWatch, &item );
+					if ( item.lParam == (LPARAM) watch )
+					{
+						ListView_RedrawItems ( mWndWatch, l, l );
+						UpdateWindow ( mWndWatch );
+						break;
+					}
+				}
+			}
+
+			break;
+		}
+
+		case DBMSG_CONNECT:
+		case DBMSG_CONNECTED:
+			UpdateTitle ( );
+			UpdateToolbar ( );
+			Printf ( "Connected...\n" );
+			break;
+
+		case DBMSG_DISCONNECT:
+			UpdateTitle ( );
+			UpdateToolbar ( );
+			Printf ( "Disconnected...\n" );
+			break;
+
+		case DBMSG_PRINT:
+		{
+			HWND prevFocus = GetFocus();
+			SetFocus ( mWndConsole );
+			SendMessage ( mWndConsole, EM_SETSEL, -1, -1 );
+			SendMessage ( mWndConsole, EM_REPLACESEL, 0, (LPARAM)(const char*)(msg->GetData()) + msg->GetReadCount() );
+			SendMessage( mWndConsole, EM_SETSEL, -1, -1 );
+			SendMessage ( mWndConsole, EM_SCROLLCARET, 0, 0 );
+			UpdateWindow( mWndConsole );
+			SetFocus( prevFocus );
+			break;
+		}
+
+		case DBMSG_BREAK:
+		{
+			Printf ( "Break:  line=%d  file='%s'\n", mClient->GetBreakLineNumber ( ), mClient->GetBreakFilename() );
+
+			mCurrentStackDepth = 0;
+			mClient->InspectVariable ( mTooltipVar, mCurrentStackDepth );
+			UpdateWatch ( );
+			UpdateBreakpointList();
+			EnableWindows ( TRUE );
+			OpenScript ( mClient->GetBreakFilename(), mClient->GetBreakLineNumber() - 1 );
+			UpdateTitle ( );
+			UpdateToolbar ( );
+			SetForegroundWindow ( mWnd );
+			break;
+		}
+		case DBMSG_INSPECTSCRIPTS:
+		{
+			UpdateScriptList ( );
+			break;
+		}
+		case DBMSG_INSPECTCALLSTACK:
+		{
+			UpdateCallstack ( );
+			break;
+		}
+
+		case DBMSG_INSPECTTHREADS:
+		{
+			LVITEM item;
+			ListView_DeleteAllItems ( mWndThreads );
+			ZeroMemory ( &item, sizeof(item) );
+			item.mask = LVIF_TEXT|LVIF_IMAGE;
+
+			for ( int i = 0; i < mClient->GetThreads().Num(); i ++ )
+			{
+				rvDebuggerThread* entry = mClient->GetThreads()[i];
+				item.iItem = ListView_GetItemCount ( mWndThreads );
+				item.pszText = "";
+				item.iImage = entry->mCurrent ? 1 : 0;
+				ListView_InsertItem ( mWndThreads, &item );
+
+				ListView_SetItemText ( mWndThreads, item.iItem, 1, (LPSTR)va("%d", entry->mID) );
+				ListView_SetItemText ( mWndThreads, item.iItem, 2, (LPSTR)entry->mName.c_str() );
+
+				if ( entry->mDying )
+				{
+					ListView_SetItemText ( mWndThreads, item.iItem, 3, "Dying" );
+				}
+				else if ( entry->mWaiting )
+				{
+					ListView_SetItemText ( mWndThreads, item.iItem, 3, "Waiting" );
+				}
+				else if ( entry->mDoneProcessing )
+				{
+					ListView_SetItemText ( mWndThreads, item.iItem, 3, "Stopped" );
+				}
+				else
+				{
+					ListView_SetItemText ( mWndThreads, item.iItem, 3, "Running" );
+				}
+			}
+			break;
+		}
+	}
+}
+
+/*
+================
+rvDebuggerWindow::Printf
+
+Sends a formatted message to the output window
+================
+*/
+void rvDebuggerWindow::Printf ( const char* fmt, ... )
+{
+	va_list		argptr;
+	char		msg[4096];
+
+	va_start (argptr,fmt);
+	vsprintf (msg,fmt,argptr);
+	va_end (argptr);
+
+	SendMessage ( mWndOutput, EM_SETSEL, -1, -1 );
+	SendMessage ( mWndOutput, EM_REPLACESEL, 0, (LPARAM)msg );
+	SendMessage ( mWndOutput, EM_SCROLLCARET, 0, 0 );
+}
+
+/*
+================
+rvDebuggerWindow::OpenScript
+
+Opens the script with the given filename and will scroll to the given line
+number if one is specified
+================
+*/
+bool rvDebuggerWindow::OpenScript ( const char* filename, int lineNumber, idProgram* program )
+{
+	int i;
+
+	SetCursor ( LoadCursor ( NULL, IDC_WAIT ) );
+
+	mActiveScript = -1;
+
+	// See if the script is already loaded
+	for ( i = 0; i < mScripts.Num(); i ++ )
+	{
+		if ( !idStr::Icmp ( mScripts[i]->GetFilename ( ), filename ) )
+		{
+			if ( mActiveScript != i )
+			{
+				mActiveScript = i;
+				break;
+			}
+		}
+	}
+
+	// If the script isnt open already then open it
+	if ( mActiveScript == -1 )
+	{
+		rvDebuggerScript* script = new rvDebuggerScript;
+
+		// Load the script
+		if ( !script->Load ( filename ) )
+		{
+			SetCursor ( LoadCursor ( NULL, IDC_ARROW ) );
+			return false;
+		}
+
+		gDebuggerApp.GetOptions().AddRecentFile ( filename );
+		UpdateRecentFiles ( );
+
+		mActiveScript = mScripts.Append ( script );
+	}
+
+	// Test code that will place a breakpoint on all valid lines of code
+#if 0
+
+	for ( i = 0; i < mScripts[mActiveScript]->GetProgram().NumStatements(); i ++ )
+	{
+		dstatement_t* st = &mScripts[mActiveScript]->GetProgram().GetStatement ( i );
+		rvDebuggerBreakpoint* bp = new rvDebuggerBreakpoint ( filename, st->linenumber );
+		mBreakpoints.Append ( bp );
+	}
+
+#endif
+
+	UpdateScript ( );
+	UpdateWindowMenu ( );
+
+	// Move to a specific line number?
+	if ( lineNumber != -1 )
+	{
+		long	c;
+
+		// Put the caret on the line number specified and scroll it into position.
+		// This is a bit of a hack since we set the selection twice, but setting the
+		// selection to (c,c) didnt work for scrolling the caret so we do (c,c+1)
+		// and then scroll before going back to (c,c).
+		// NOTE: We scroll to the line before the one we want so its more visible
+		SetFocus ( mWndScript );
+		c = SendMessage ( mWndScript, EM_LINEINDEX, (long)lineNumber - 1, 0 );
+		SendMessage ( mWndScript, EM_SETSEL, c, c + 1 );
+		SendMessage ( mWndScript, EM_SCROLLCARET, 0, 0 );
+		c = SendMessage ( mWndScript, EM_LINEINDEX, (long)lineNumber, 0 );
+		SendMessage ( mWndScript, EM_SETSEL, c, c );
+	}
+	else
+	{
+		SendMessage ( mWndScript, EM_SETSEL, 0, 0 );
+	}
+
+	// Make sure the script window is visible
+	ShowWindow ( mWndScript, SW_SHOW );
+	UpdateWindow ( mWndScript );
+
+	SetCursor ( LoadCursor ( NULL, IDC_ARROW ) );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerWindow::ToggleBreakpoint
+
+Toggles the breakpoint on the current script line
+================
+*/
+void rvDebuggerWindow::ToggleBreakpoint ( void )
+{
+	rvDebuggerBreakpoint* bp;
+	DWORD				  sel;
+	int				      line;
+
+	// Find the currently selected line
+	SendMessage ( mWndScript, EM_GETSEL, (WPARAM)&sel, 0 );
+	line = SendMessage ( mWndScript, EM_LINEFROMCHAR, sel, 0 ) + 1;
+
+	// If there is already a breakpoint there then just remove it, otherwise
+	// we need to create a new breakpoint
+	bp = mClient->FindBreakpoint ( mScripts[mActiveScript]->GetFilename ( ), line );
+	if ( !bp )
+	{
+		// Make sure the line is code before letting them add a breakpoint there
+		if ( !mScripts[mActiveScript]->IsLineCode ( line ) )
+		{
+			MessageBeep ( MB_ICONEXCLAMATION );
+			return;
+		}
+
+		mClient->AddBreakpoint ( mScripts[mActiveScript]->GetFilename(), line );
+	}
+	else
+	{
+		mClient->RemoveBreakpoint ( bp->GetID ( ) );
+	}
+
+	// Force a repaint of the script window
+	InvalidateRect ( mWndScript, NULL, FALSE );
+
+	UpdateBreakpointList();
+}
+
+/*
+================
+rvDebuggerWindow::AboutDlgProc
+
+Dialog box procedure for the about box
+================
+*/
+INT_PTR CALLBACK rvDebuggerWindow::AboutDlgProc ( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+	switch ( msg )
+	{
+		case WM_COMMAND:
+			EndDialog ( wnd, 0 );
+			break;
+	}
+
+	return FALSE;
+}
+
+/*
+================
+rvDebuggerWindow::CreateToolbar
+
+Create the toolbar and and all of its buttons
+================
+*/
+void rvDebuggerWindow::CreateToolbar ( void )
+{
+	// Create the toolbar control
+	mWndToolbar = CreateWindowEx ( 0, TOOLBARCLASSNAME, "", WS_CHILD|WS_VISIBLE,0,0,0,0, mWnd, (HMENU)IDC_DBG_TOOLBAR, mInstance, NULL );
+
+	// Initialize the toolbar
+	SendMessage ( mWndToolbar, TB_BUTTONSTRUCTSIZE, ( WPARAM )sizeof( TBBUTTON ), 0 );
+	SendMessage ( mWndToolbar, TB_SETBUTTONSIZE, 0, MAKELONG(16,16) );
+	SendMessage ( mWndToolbar, TB_SETSTYLE, 0, SendMessage ( mWndToolbar, TB_GETSTYLE, 0, 0 ) | TBSTYLE_FLAT | TBSTYLE_TOOLTIPS );
+
+	TBMETRICS tbmet;
+	tbmet.cbSize = sizeof(TBMETRICS);
+	SendMessage ( mWndToolbar, TB_GETMETRICS, 0, (LPARAM)&tbmet );
+	tbmet.cyPad = 0;
+	tbmet.cyBarPad = 0;
+	SendMessage ( mWndToolbar, TB_SETMETRICS, 0, (LPARAM)&tbmet );
+
+	// Add the bitmap containing button images to the toolbar.
+	TBADDBITMAP	tbab;
+	tbab.hInst = mInstance;
+	tbab.nID = IDB_DBG_TOOLBAR;
+	SendMessage( mWndToolbar, TB_ADDBITMAP, (WPARAM)4, (LPARAM) &tbab );
+
+	// Add the buttons to the toolbar
+	// FIXME:  warning C4838: conversion from 'int' to 'BYTE' requires a narrowing conversion
+	// most probably because TBBUTTON has 4 more bytes in bReserved for alignment on _WIN64
+	TBBUTTON tbb[] = { { 0, 0,					TBSTATE_ENABLED, BTNS_SEP,    0, 0, -1 },
+					   { 8, ID_DBG_FILE_OPEN,	TBSTATE_ENABLED, BTNS_BUTTON, 0, 0, -1 },
+					   { 0, 0,					TBSTATE_ENABLED, BTNS_SEP,    0, 0, -1 },
+					   { 0, ID_DBG_DEBUG_RUN,	TBSTATE_ENABLED, BTNS_BUTTON, 0, 0, -1 },
+					   { 1, ID_DBG_DEBUG_BREAK, TBSTATE_ENABLED, BTNS_BUTTON, 0, 0, -1 },
+					   { 0, 0,					TBSTATE_ENABLED, BTNS_SEP,    0, 0, -1 },
+					   { 4, ID_DBG_DEBUG_STEPINTO, TBSTATE_ENABLED, BTNS_BUTTON, 0, 0, -1 },
+					   { 5, ID_DBG_DEBUG_STEPOVER, TBSTATE_ENABLED, BTNS_BUTTON, 0, 0, -1 },
+					   { 6, ID_DBG_DEBUG_STEPOUT, TBSTATE_ENABLED, BTNS_BUTTON, 0, 0, -1 },
+					   { 0, 0,					TBSTATE_ENABLED, BTNS_SEP,    0, 0, -1 } };
+
+	SendMessage( mWndToolbar, TB_ADDBUTTONS, (WPARAM)sizeof(tbb)/sizeof(TBBUTTON), (LPARAM) tbb );
+}
+
+/*
+================
+rvDebuggerWindow::HandleTooltipGetDispInfo
+
+Handle the getdispinfo notification message for tooltips by responding with the
+tooptip text for the given toolbar button.
+================
+*/
+void rvDebuggerWindow::HandleTooltipGetDispInfo ( WPARAM wparam, LPARAM lparam )
+{
+	NMTTDISPINFO* ttdi = (NMTTDISPINFO*) lparam;
+	switch ( ttdi->hdr.idFrom )
+	{
+		case ID_DBG_FILE_OPEN:
+			strcpy ( ttdi->szText, "Open Script" );
+			break;
+
+		case ID_DBG_DEBUG_STEPINTO:
+			strcpy ( ttdi->szText, "Step Into" );
+			break;
+
+		case ID_DBG_DEBUG_STEPOVER:
+			strcpy ( ttdi->szText, "Step Over" );
+			break;
+
+		case ID_DBG_DEBUG_STEPOUT:
+			strcpy ( ttdi->szText, "Step Out" );
+			break;
+
+		case ID_DBG_DEBUG_BREAK:
+			strcpy ( ttdi->szText, "Break" );
+			break;
+
+		case ID_DBG_DEBUG_RUN:
+			if ( mClient->IsConnected() )
+			{
+				strcpy ( ttdi->szText, "Continue" );
+			}
+			else
+			{
+				strcpy ( ttdi->szText, "Run" );
+			}
+			break;
+
+		default:
+			strcpy ( ttdi->szText, "" );
+			break;
+	}
+}
+
+/*
+================
+rvDebuggerWindow::HandleActivate
+
+When the main window is activated, check all the loaded scripts and see if any of them
+have been modified since the last time they were loaded.  If they have then reload
+them and adjust all breakpoints that now fall on invalid lines.
+================
+*/
+int rvDebuggerWindow::HandleActivate ( WPARAM wparam, LPARAM lparam )
+{
+	int i;
+
+	// We are only interested in the activation, not deactivation
+	if ( !LOWORD(wparam) )
+	{
+		return 0;
+	}
+
+	// Run through all of the loaded scripts and see if any of them have been modified
+	for ( i = 0; i < mScripts.Num(); i ++ )
+	{
+		if ( mScripts[i]->IsFileModified ( true ) )
+		{
+			if ( IDYES == MessageBox ( mWnd, va("%s\n\nThis file has been modified outside of the debugger.\nDo you want to reload it?", mScripts[i]->GetFilename() ), "Quake 4 Script Debugger", MB_YESNO|MB_ICONQUESTION ) )
+			{
+				mScripts[i]->Reload ( );
+
+				// Update the script if it was the active one
+				if ( mActiveScript == i )
+				{
+					mLastActiveScript = -1;
+					UpdateScript ( );
+				}
+
+				// Loop through the breakpoints and see if any of them have
+				// moved to invalid lines within the script.  If so then just remove
+				// them.
+				for ( int b = mClient->GetBreakpointCount() - 1; b >= 0 ; b-- )
+				{
+					rvDebuggerBreakpoint* bp = mClient->GetBreakpoint(b);
+					assert ( bp );
+
+					if ( !idStr::Icmp ( bp->GetFilename(), mScripts[i]->GetFilename() ) )
+					{
+						if ( !mScripts[i]->IsLineCode ( bp->GetLineNumber ( ) ) )
+						{
+							mClient->RemoveBreakpoint ( bp->GetID ( ) );
+						}
+					}
+				}
+			}
+		}
+	}
+	UpdateBreakpointList();
+
+	return 1;
+}
+
+/*
+================
+rvDebuggerWindow::EnableWindows
+
+Enables and disables all windows with a enable state dependent on the current
+connected and paused state of the debugger.
+================
+*/
+void rvDebuggerWindow::EnableWindows ( bool state )
+{
+	EnableWindow ( mWndCallstack, state );
+	EnableWindow ( mWndThreads, state );
+	EnableWindow ( mWndWatch, state );
+}
+
+/*
+================
+rvDebuggerWindow::AddWatch
+
+Add a variable to the watch window.  If update is set to true then also query the
+debugger client for the value
+================
+*/
+void rvDebuggerWindow::AddWatch ( const char* varname, bool update )
+{
+	rvDebuggerWatch* watch;
+
+	watch = new rvDebuggerWatch;
+	watch->mVariable = varname;
+	watch->mModified = false;
+	watch->mValue = "???";
+	mWatches.Append ( watch );
+
+	// Add the variable to the watch control
+	LVITEM item;
+	item.mask = LVIF_PARAM;
+	item.iItem = ListView_GetItemCount ( mWndWatch ) - 1;
+	item.iSubItem = 0;
+	item.lParam = (LPARAM)watch;
+	ListView_InsertItem ( mWndWatch, &item );
+
+	// If update is set then request the value from the debugger client
+	if ( update )
+	{
+		mClient->InspectVariable ( varname, mCurrentStackDepth );
+	}
+}
+
+/*
+================
+rvDebuggerWindow::InitRecentFiles
+
+Finds the file menu and the location within it where the MRU should
+be added.
+================
+*/
+bool rvDebuggerWindow::InitRecentFiles ( void )
+{
+	int	i;
+	int count;
+
+	mRecentFileMenu = GetSubMenu ( GetMenu(mWnd), 0 );
+	count			= GetMenuItemCount ( mRecentFileMenu );
+
+	for ( i = 0; i < count; i ++ )
+	{
+		if ( GetMenuItemID ( mRecentFileMenu, i ) == ID_DBG_FILE_MRU )
+		{
+			mRecentFileInsertPos = i;
+			DeleteMenu ( mRecentFileMenu, mRecentFileInsertPos, MF_BYPOSITION );
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+================
+rvDebuggerWindow::UpdateRecentFiles
+
+Updates the mru in the menu
+================
+*/
+void rvDebuggerWindow::UpdateRecentFiles ( void )
+{
+	int i;
+	int j;
+
+	// Make sure everything is initialized
+	if ( !mRecentFileMenu )
+	{
+		InitRecentFiles ( );
+	}
+
+	// Delete all the old recent files from the menu's
+	for ( i = 0; i < rvRegistryOptions::MAX_MRU_SIZE; i ++ )
+	{
+		DeleteMenu ( mRecentFileMenu, ID_DBG_FILE_MRU1 + i, MF_BYCOMMAND );
+	}
+
+	// Make sure there is a separator after the recent files
+	if ( gDebuggerApp.GetOptions().GetRecentFileCount() )
+	{
+		MENUITEMINFO info;
+		ZeroMemory ( &info, sizeof(info) );
+		info.cbSize = sizeof(info);
+		info.fMask = MIIM_FTYPE;
+		GetMenuItemInfo ( mRecentFileMenu, mRecentFileInsertPos+1,TRUE, &info );
+		if ( !(info.fType & MFT_SEPARATOR ) )
+		{
+			InsertMenu ( mRecentFileMenu, mRecentFileInsertPos, MF_BYPOSITION|MF_SEPARATOR|MF_ENABLED, 0, NULL );
+		}
+	}
+
+	// Add the recent files to the menu now
+	for ( j = 0, i = gDebuggerApp.GetOptions().GetRecentFileCount ( ) - 1; i >= 0; i --, j++ )
+	{
+		UINT id = ID_DBG_FILE_MRU1 + j;
+		idStr str = va("&%d ", j+1);
+		str.Append ( gDebuggerApp.GetOptions().GetRecentFile ( i ) );
+		InsertMenu ( mRecentFileMenu, mRecentFileInsertPos+j+1, MF_BYPOSITION|MF_STRING|MF_ENABLED, id, str );
+	}
+}
+
+/*
+================
+rvDebuggerWindow::GetSelectedText
+
+Function to retrieve the text that is currently selected in the
+script control
+================
+*/
+int rvDebuggerWindow::GetSelectedText ( idStr& text )
+{
+	TEXTRANGE	range;
+	int			start;
+	int			end;
+	char*		temp;
+
+	text.Empty ( );
+
+	if ( mScripts.Num ( ) )
+	{
+		SendMessage ( mWndScript, EM_GETSEL, (WPARAM)&start, (LPARAM)&end );
+		if ( start == end )
+		{
+			end   = SendMessage ( mWndScript, EM_FINDWORDBREAK, WB_RIGHT, start );
+			start = SendMessage ( mWndScript, EM_FINDWORDBREAK, WB_LEFT, start );
+		}
+
+		temp = new char[end-start+10];
+		range.chrg.cpMin = start;
+		range.chrg.cpMax = end;
+		range.lpstrText  = temp;
+		SendMessage ( mWndScript, EM_GETTEXTRANGE, 0, (LPARAM) &range );
+		text = temp;
+		delete[] temp;
+
+		return start;
+	}
+
+	return -1;
+}
+
+/*
+================
+rvDebuggerWindow::FindNext
+
+Finds the next match of the find text in the active script.  The next is
+always relative to the current selection.  If the text parameter is NULL
+then the last text used will be searched for.
+================
+*/
+bool rvDebuggerWindow::FindNext ( const char* text )
+{
+	long	 start;
+	FINDTEXT ft;
+
+	if ( text )
+	{
+		mFind = text;
+	}
+
+	if ( !mFind.Length ( ) )
+	{
+		return false;
+	}
+
+	SendMessage ( mWndScript, EM_GETSEL, (WPARAM)&start, (LPARAM)0 );
+	if ( start < 0 )
+	{
+		start = 0;
+	}
+
+	ft.chrg.cpMin = start + 1;
+	ft.chrg.cpMax = -1;
+	ft.lpstrText = mFind.c_str();
+	start = SendMessage ( mWndScript, EM_FINDTEXT, FR_DOWN, (LPARAM)&ft );
+
+	if ( start < 0 )
+	{
+		ft.chrg.cpMin = 0;
+		ft.chrg.cpMax = -1;
+		ft.lpstrText = mFind.c_str();
+		start = SendMessage ( mWndScript, EM_FINDTEXT, FR_DOWN, (LPARAM)&ft );
+
+		if ( start < 0 )
+		{
+			return false;
+		}
+	}
+
+	SendMessage ( mWndScript, EM_SETSEL, start, start + (long)mFind.Length() );
+	SendMessage ( mWndScript, EM_SCROLLCARET, 0, 0 );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerWindow::FindPrev
+
+Finds the previous match of the find text in the active script.  The previous is
+always relative to the current selection.  If the text parameter is NULL
+then the last text used will be searched for.
+================
+*/
+bool rvDebuggerWindow::FindPrev ( const char* text )
+{
+	long	 start;
+	FINDTEXT ft;
+
+	if ( text )
+	{
+		mFind = text;
+	}
+
+	if ( !mFind.Length ( ) )
+	{
+		return false;
+	}
+
+	SendMessage ( mWndScript, EM_GETSEL, (WPARAM)&start, (LPARAM)0 );
+	if ( start < 0 )
+	{
+		start = 0;
+	}
+
+	ft.chrg.cpMin = start;
+	ft.chrg.cpMax = -1;
+	ft.lpstrText = mFind.c_str();
+	start = SendMessage ( mWndScript, EM_FINDTEXT, 0, (LPARAM)&ft );
+
+	if ( start < 0 )
+	{
+		GETTEXTLENGTHEX gtl;
+		gtl.flags = GTL_DEFAULT;
+		gtl.codepage = CP_ACP;
+		ft.chrg.cpMin = SendMessage ( mWndScript, EM_GETTEXTLENGTHEX, (WPARAM)&gtl, 0 );
+		ft.chrg.cpMax = 0;
+		ft.lpstrText = mFind.c_str();
+		start = SendMessage ( mWndScript, EM_FINDTEXT, 0, (LPARAM)&ft );
+
+		if ( start < 0 )
+		{
+			return false;
+		}
+	}
+
+	SendMessage ( mWndScript, EM_SETSEL, start, start + mFind.Length() );
+	SendMessage ( mWndScript, EM_SCROLLCARET, 0, 0 );
+
+	return true;
+}
+
+/*
+================
+rvDebuggerWindow::HandleDrawItem
+
+Handled the WM_DRAWITEM message.  The watch window is custom drawn so a grid can be displayed.
+================
+*/
+int rvDebuggerWindow::HandleDrawItem ( WPARAM wparam, LPARAM lparam )
+{
+	DRAWITEMSTRUCT*		dis;
+	LVCOLUMN			col;
+	int					index;
+	idStr				widths;
+	RECT				rect;
+	rvDebuggerWatch*	watch;
+	bool				selected;
+
+	dis        = (DRAWITEMSTRUCT*) lparam;
+	watch	   = (rvDebuggerWatch*)dis->itemData;
+
+	col.mask   = LVCF_WIDTH;
+	rect       = dis->rcItem;
+	rect.left  = rect.left - 1;
+	rect.right = rect.left;
+	rect.bottom++;
+
+	selected = ((dis->itemState & ODS_SELECTED) && GetFocus()==mWndWatch);
+
+	// Set the colors based on the selected state and draw the item background
+	if ( selected )
+	{
+		FillRect ( dis->hDC, &dis->rcItem, GetSysColorBrush ( COLOR_HIGHLIGHT ) );
+	}
+	else
+	{
+		FillRect ( dis->hDC, &dis->rcItem, GetSysColorBrush ( IsWindowEnabled ( mWndWatch ) ? COLOR_WINDOW : COLOR_3DFACE ) );
+	}
+
+	// Run through the columns and draw each with a frame around it and the text
+	// vertically centered in it
+	for ( index = 0; ListView_GetColumn ( mWndWatch, index, &col ); index ++ )
+	{
+		rect.right = rect.left + col.cx;
+		FrameRect ( dis->hDC, &rect, GetSysColorBrush ( COLOR_3DFACE ) );
+
+		// Draw info on the watch if available
+		if ( watch  )
+		{
+			RECT textrect;
+			textrect = rect;
+			textrect.left += 5;
+
+			switch ( index )
+			{
+				case 0:
+					SetTextColor ( dis->hDC, GetSysColor ( selected ? COLOR_HIGHLIGHTTEXT : COLOR_WINDOWTEXT ) );
+					DrawText ( dis->hDC, watch->mVariable, -1, &textrect, DT_LEFT|DT_VCENTER );
+					break;
+
+				case 1:
+					if ( watch && watch->mModified && (IsWindowEnabled ( mWndWatch ) ) )
+					{
+						SetTextColor ( dis->hDC, RGB(255,50,50) );
+					}
+					else
+					{
+						SetTextColor ( dis->hDC, GetSysColor ( selected ? COLOR_HIGHLIGHTTEXT : COLOR_WINDOWTEXT ) );
+					}
+					DrawText ( dis->hDC, watch->mValue, -1, &textrect, DT_LEFT|DT_VCENTER );
+					break;
+			}
+		}
+
+		rect.left = rect.right - 1;
+	}
+
+	return 0;
+}

--- a/tools/debugger/DebuggerWindow.cpp
+++ b/tools/debugger/DebuggerWindow.cpp
@@ -26,9 +26,6 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-#include "tools/edit_gui_common.h"
-
-
 #include "../../sys/win32/rc/debugger_resource.h"
 #include "DebuggerApp.h"
 #include "../Common/OpenFileDialog.h"
@@ -54,6 +51,13 @@ If you have questions concerning this license or the applicable additional terms
 #define IDC_DBG_BREAKLIST		31012
 
 #define ID_DBG_FILE_MRU1		10000
+
+// Hack: dhewm3 supports scaling all MFC GUIs for display DPI
+//  and has Win_GetWindowScalingFactor() for getting the required factor.
+//  TDM doesn't have this, so for now provide a stub so the script debugger works
+static float Win_GetWindowScalingFactor(HWND window) {
+	return 1.0f;
+}
 
 /*
 ================
@@ -298,7 +302,7 @@ LRESULT CALLBACK rvDebuggerWindow::ScriptWndProc ( HWND wnd, UINT msg, WPARAM wp
 				ti.hwnd   = wnd;
 				ti.uId    = 0;
 				SendMessage ( window->mWndToolTips, TTM_DELTOOL, 0, (LPARAM) (LPTOOLINFO) &ti );
-				window->mTooltipVar.Empty ( );
+				window->mTooltipVar.Clear();
 			}
 
 			// If there is no word then ignore it
@@ -2529,7 +2533,7 @@ int rvDebuggerWindow::GetSelectedText ( idStr& text )
 	int			end;
 	char*		temp;
 
-	text.Empty ( );
+	text.Clear();
 
 	if ( mScripts.Num ( ) )
 	{

--- a/tools/debugger/DebuggerWindow.h
+++ b/tools/debugger/DebuggerWindow.h
@@ -1,0 +1,187 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef DEBUGGERWINDOW_H_
+#define DEBUGGERWINDOW_H_
+
+#ifndef DEBUGGERSCRIPT_H_
+#include "DebuggerScript.h"
+#endif
+
+class rvDebuggerWatch
+{
+public:
+
+	idStr	mVariable;
+	idStr	mValue;
+	bool	mModified;
+};
+
+typedef idList<rvDebuggerWatch*>		rvDebuggerWatchList;
+
+class rvDebuggerClient;
+
+class rvDebuggerWindow
+{
+public:
+
+	rvDebuggerWindow ( );
+	~rvDebuggerWindow ( );
+
+	bool							Create				( HINSTANCE hInstance );
+
+	static bool						Activate			( void );
+
+	void							ProcessNetMessage	( idBitMsg * msg );
+
+	void							Printf				( const char* format, ... );
+
+	HWND							GetWindow			( void );
+
+	void							AddWatch			( const char* name, bool update = true );
+
+	HINSTANCE						GetInstance			( void );
+
+private:
+	bool							RegisterClass	( void );
+	void							CreateToolbar	( void );
+	bool							InitRecentFiles	( void );
+
+	int								HandleInitMenu			( WPARAM wParam, LPARAM lParam );
+	int								HandleCommand			( WPARAM wParam, LPARAM lParam );
+	int								HandleCreate			( WPARAM wparam, LPARAM lparam );
+	int								HandleActivate			( WPARAM wparam, LPARAM lparam );
+	int								HandleDrawItem			( WPARAM wparam, LPARAM lparam );
+	void							HandleTooltipGetDispInfo( WPARAM wparam, LPARAM lparam );
+
+	void							ResizeImageList				( int& widthOut, int& heightOut);
+	static LRESULT					CALLBACK WndProc			( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam );
+	static LRESULT					CALLBACK MarginWndProc		( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam );
+	static LRESULT					CALLBACK ScriptWndProc		( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam );
+	static INT_PTR					CALLBACK AboutDlgProc		( HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam );
+	static int						CALLBACK ScriptWordBreakProc( LPTSTR text, int current, int max, int action );
+
+	bool							FindPrev			( const char* text = NULL );
+	bool							FindNext			( const char* text = NULL );
+
+	void							UpdateBreakpointList( void );
+	void							UpdateScriptList	( void );
+	void							UpdateWatch			( void );
+	void							UpdateWindowMenu	( void );
+	void							UpdateScript		( void );
+	void							UpdateToolbar		( void );
+	void							UpdateTitle			( void );
+	void							UpdateCallstack		( void );
+	void							UpdateRecentFiles	( void );
+	bool							OpenScript			( const char* filename, int lineNumber = -1, idProgram* program = NULL );
+	void							EnableWindows		( bool state );
+
+	int								GetSelectedText		( idStr& text );
+
+	void							ToggleBreakpoint	( void );
+	float							GetMarginWidth      ( void );
+	HWND							mWnd;
+	HWND							mWndScript;
+	HWND							mWndOutput;
+	HWND							mWndMargin;
+	HWND							mWndTabs;
+	HWND							mWndBorder;
+	HWND							mWndConsole;
+	HWND							mWndConsoleInput;
+	HWND							mWndCallstack;
+	HWND							mWndScriptList;
+	HWND							mWndBreakList; // list of breakpoints
+	HWND							mWndWatch;
+	HWND							mWndThreads;
+	HWND							mWndToolTips;
+	HWND							mWndToolbar;
+
+	HMENU							mRecentFileMenu;
+	int								mRecentFileInsertPos;
+
+	WNDPROC							mOldWatchProc;
+	WNDPROC							mOldScriptProc;
+	idStr							mTooltipVar;
+	idStr							mTooltipValue;
+
+	HINSTANCE						mInstance;
+	HIMAGELIST						mImageList;
+	HIMAGELIST						mTmpImageList;
+
+	RECT							mSplitterRect;
+	bool							mSplitterDrag;
+
+	idList<rvDebuggerScript*>		mScripts;
+	int								mActiveScript;
+	int								mLastActiveScript;
+	int								mCurrentStackDepth;
+
+	HMENU							mWindowMenu;
+	int								mWindowMenuPos;
+
+	int								mZoomScaleNum;
+	int								mZoomScaleDem;
+	int								mMarginSize;
+
+	idStr							mFind;
+
+	rvDebuggerClient*				mClient;
+
+	rvDebuggerWatchList				mWatches;
+};
+
+/*
+================
+rvDebuggerWindow::GetWindow
+================
+*/
+ID_INLINE HWND rvDebuggerWindow::GetWindow ( void )
+{
+	return mWnd;
+}
+
+/*
+================
+rvDebuggerWindow::UpdateToolbar
+================
+*/
+ID_INLINE void rvDebuggerWindow::UpdateToolbar ( void )
+{
+	HandleInitMenu ( (WPARAM)GetMenu ( mWnd ), 0 );
+}
+
+/*
+================
+rvDebuggerWindow::GetInstance
+================
+*/
+ID_INLINE HINSTANCE rvDebuggerWindow::GetInstance ( void )
+{
+	return mInstance;
+}
+
+#endif // DEBUGGERWINDOW_H_

--- a/tools/debugger/debugger.cpp
+++ b/tools/debugger/debugger.cpp
@@ -1,0 +1,254 @@
+/*
+===========================================================================
+
+Doom 3 GPL Source Code
+Copyright (C) 1999-2011 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 GPL Source Code ("Doom 3 Source Code").
+
+Doom 3 Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+
+
+#if defined( ID_ALLOW_TOOLS )
+#include "tools/edit_gui_common.h"
+#include "DebuggerServer.h"
+#include "../../sys/win32/rc/debugger_resource.h"
+#include "DebuggerApp.h"
+#else
+#include "DebuggerServer.h"
+#include "debugger_common.h"
+#endif
+
+#if defined( ID_ALLOW_TOOLS )
+rvDebuggerApp					gDebuggerApp; // this is also used in other source files
+static HWND						gDebuggerWindow = NULL;
+#endif
+
+static rvDebuggerServer*		gDebuggerServer			= NULL;
+static SDL_Thread*				gDebuggerServerThread   = NULL;
+static bool						gDebuggerServerQuit     = false;
+
+#if defined( ID_ALLOW_TOOLS )
+/*
+================
+DebuggerMain
+
+Main entry point for the debugger application
+================
+*/
+void DebuggerClientInit( const char *cmdline )
+{
+	// See if the debugger is already running
+	if ( rvDebuggerWindow::Activate ( ) )
+	{
+		goto DebuggerClientInitDone;
+	}
+
+	if ( !gDebuggerApp.Initialize ( win32.hInstance ) )
+	{
+		goto DebuggerClientInitDone;
+	}
+	
+	// hide the doom window by default
+	::ShowWindow( win32.hWnd, SW_HIDE );
+
+	gDebuggerApp.Run ( );
+
+DebuggerClientInitDone:
+
+	common->Quit();
+}
+
+/*
+================
+DebuggerLaunch
+
+Launches another instance of the running executable with +debugger appended
+to the end to indicate that the debugger should start up.
+================
+*/
+void DebuggerClientLaunch ( void )
+{
+	if ( renderSystem->IsFullScreen() ) {
+		common->Printf( "Cannot run the script debugger in fullscreen mode.\n"
+					"Set r_fullscreen to 0 and vid_restart.\n" );
+		return;
+	}
+
+	// See if the debugger is already running
+	if ( rvDebuggerWindow::Activate ( ) ) {
+		return;
+	}
+
+	char exeFile[MAX_PATH];
+	char curDir[MAX_PATH];
+
+	STARTUPINFO			startup;
+	PROCESS_INFORMATION	process;
+
+	ZeroMemory ( &startup, sizeof(startup) );
+	startup.cb = sizeof(startup);
+
+	GetCurrentDirectory ( MAX_PATH, curDir );
+
+	GetModuleFileName ( NULL, exeFile, MAX_PATH );
+	const char* s = va("%s +set fs_game %s +set fs_basepath %s +debugger", exeFile, cvarSystem->GetCVarString( "fs_game" ), cvarSystem->GetCVarString( "fs_basepath" ) );
+	CreateProcess ( NULL, (LPSTR)s,
+					NULL, NULL, FALSE, 0, NULL, curDir, &startup, &process );
+
+	CloseHandle ( process.hThread );
+	CloseHandle ( process.hProcess );
+}
+#endif // #if defined( ID_ALLOW_TOOLS )
+
+/*
+================
+DebuggerServerThread
+
+Thread proc for the debugger server
+================
+*/
+static int SDLCALL DebuggerServerThread ( void *param )
+{
+	assert ( gDebuggerServer );
+
+	while ( !gDebuggerServerQuit )
+	{
+		gDebuggerServer->ProcessMessages ( );
+		SDL_Delay( 1 );
+	}
+
+	return 0;
+}
+
+/*
+================
+DebuggerServerInit
+
+Starts up the debugger server
+================
+*/
+bool DebuggerServerInit ( void )
+{
+	com_enableDebuggerServer.ClearModified( );
+
+	if ( !com_debuggerSupported )
+	{
+		common->Warning( "Called DebuggerServerInit() without the gameDLL supporting it!\n" );
+		return false;
+	}
+
+	// Dont do this if we are in the debugger already
+	if ( gDebuggerServer != NULL 
+		|| ( com_editors & EDITOR_DEBUGGER ) )
+	{
+		return false;
+	}
+
+	// Allocate the new debugger server
+	gDebuggerServer = new rvDebuggerServer;
+	if ( !gDebuggerServer )
+	{
+		return false;
+	}
+
+	// Initialize the debugger server
+	if ( !gDebuggerServer->Initialize ( ) )
+	{
+		delete gDebuggerServer;
+		gDebuggerServer = NULL;
+		return false;
+	}
+	
+	// Start the debugger server thread
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	gDebuggerServerThread = SDL_CreateThread( DebuggerServerThread, "DebuggerServer", NULL );
+#else // SDL 1.2
+	gDebuggerServerThread = SDL_CreateThread( DebuggerServerThread, NULL );
+#endif
+
+	return true;
+}
+
+/*
+================
+DebuggerServerShutdown
+
+Shuts down the debugger server
+================
+*/
+void DebuggerServerShutdown ( void )
+{
+	if ( gDebuggerServerThread != NULL )
+	{
+		// Signal the debugger server to quit
+		gDebuggerServerQuit = true;
+
+		// Wait for the thread to finish
+		SDL_WaitThread( gDebuggerServerThread, NULL );
+		gDebuggerServerThread = NULL;
+
+		// Shutdown the server now
+		gDebuggerServer->Shutdown();
+
+		delete gDebuggerServer;
+		gDebuggerServer = NULL;
+
+		com_editors &= ~EDITOR_DEBUGGER;
+	}
+
+	com_enableDebuggerServer.ClearModified( );
+}
+
+/*
+================
+DebuggerServerCheckBreakpoint
+
+Check to see if there is a breakpoint associtated with this statement
+================
+*/
+void DebuggerServerCheckBreakpoint ( idInterpreter* interpreter, idProgram* program, int instructionPointer )
+{
+	if ( !gDebuggerServer )
+	{
+		return;
+	}
+
+	gDebuggerServer->CheckBreakpoints ( interpreter, program, instructionPointer );
+}
+
+/*
+================
+DebuggerServerPrint
+
+Sends a print message to the debugger client
+================
+*/
+void DebuggerServerPrint ( const char* text )
+{
+	if ( !gDebuggerServer )
+	{
+		return;
+	}
+
+	gDebuggerServer->Print ( text );
+}

--- a/tools/debugger/debugger.cpp
+++ b/tools/debugger/debugger.cpp
@@ -44,7 +44,7 @@ static HWND						gDebuggerWindow = NULL;
 #endif
 
 static rvDebuggerServer*		gDebuggerServer			= NULL;
-static SDL_Thread*				gDebuggerServerThread   = NULL;
+static uintptr_t				gDebuggerServerThread = 0;
 static bool						gDebuggerServerQuit     = false;
 
 #if defined( ID_ALLOW_TOOLS )
@@ -127,14 +127,14 @@ DebuggerServerThread
 Thread proc for the debugger server
 ================
 */
-static int SDLCALL DebuggerServerThread ( void *param )
+static unsigned int DebuggerServerThread ( void *param )
 {
 	assert ( gDebuggerServer );
 
 	while ( !gDebuggerServerQuit )
 	{
 		gDebuggerServer->ProcessMessages ( );
-		SDL_Delay( 1 );
+		Sys_Sleep(1);
 	}
 
 	return 0;
@@ -150,12 +150,6 @@ Starts up the debugger server
 bool DebuggerServerInit ( void )
 {
 	com_enableDebuggerServer.ClearModified( );
-
-	if ( !com_debuggerSupported )
-	{
-		common->Warning( "Called DebuggerServerInit() without the gameDLL supporting it!\n" );
-		return false;
-	}
 
 	// Dont do this if we are in the debugger already
 	if ( gDebuggerServer != NULL 
@@ -180,11 +174,7 @@ bool DebuggerServerInit ( void )
 	}
 	
 	// Start the debugger server thread
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	gDebuggerServerThread = SDL_CreateThread( DebuggerServerThread, "DebuggerServer", NULL );
-#else // SDL 1.2
-	gDebuggerServerThread = SDL_CreateThread( DebuggerServerThread, NULL );
-#endif
+	gDebuggerServerThread = Sys_CreateThread(DebuggerServerThread, NULL, THREAD_NORMAL, "DebuggerServer");
 
 	return true;
 }
@@ -198,14 +188,14 @@ Shuts down the debugger server
 */
 void DebuggerServerShutdown ( void )
 {
-	if ( gDebuggerServerThread != NULL )
+	if ( gDebuggerServerThread != 0 )
 	{
 		// Signal the debugger server to quit
 		gDebuggerServerQuit = true;
 
 		// Wait for the thread to finish
-		SDL_WaitThread( gDebuggerServerThread, NULL );
-		gDebuggerServerThread = NULL;
+		Sys_DestroyThread( gDebuggerServerThread );
+		gDebuggerServerThread = 0;
 
 		// Shutdown the server now
 		gDebuggerServer->Shutdown();

--- a/tools/debugger/debugger.cpp
+++ b/tools/debugger/debugger.cpp
@@ -29,7 +29,6 @@ If you have questions concerning this license or the applicable additional terms
 
 
 #if defined( ID_ALLOW_TOOLS )
-#include "tools/edit_gui_common.h"
 #include "DebuggerServer.h"
 #include "../../sys/win32/rc/debugger_resource.h"
 #include "DebuggerApp.h"

--- a/tools/debugger/debugger_common.h
+++ b/tools/debugger/debugger_common.h
@@ -1,0 +1,161 @@
+// header that includes all the other needed headers, replacement for precompiled.h (only used by debugger)
+// this could be cleaned up more.
+
+#ifndef DEBUGGER_COMMON_H
+#define DEBUGGER_COMMON_H
+
+#include "game/Game.h"
+
+// non-portable system services
+//#include "sys/platform.h"
+#include "sys/sys_public.h"
+
+// id lib
+#include "idlib/Lib.h"
+
+// memory management and arrays
+#include "idlib/Heap.h"
+#include "idlib/containers/List.h"
+
+// math
+#include "idlib/math/Simd.h"
+#include "idlib/math/Math.h"
+#include "idlib/math/Random.h"
+#include "idlib/math/Complex.h"
+#include "idlib/math/Vector.h"
+#include "idlib/math/Matrix.h"
+#include "idlib/math/Angles.h"
+#include "idlib/math/Quat.h"
+#include "idlib/math/Rotation.h"
+#include "idlib/math/Plane.h"
+#include "idlib/math/Pluecker.h"
+#include "idlib/math/Polynomial.h"
+#include "idlib/math/Extrapolate.h"
+#include "idlib/math/Interpolate.h"
+#include "idlib/math/Curve.h"
+#include "idlib/math/Ode.h"
+#include "idlib/math/Lcp.h"
+
+// bounding volumes
+#include "idlib/bv/Sphere.h"
+#include "idlib/bv/Bounds.h"
+#include "idlib/bv/Box.h"
+#include "idlib/bv/Frustum.h"
+
+// geometry
+#include "idlib/geometry/DrawVert.h"
+#include "idlib/geometry/JointTransform.h"
+#include "idlib/geometry/Winding.h"
+#include "idlib/geometry/Winding2D.h"
+#include "idlib/geometry/Surface.h"
+#include "idlib/geometry/Surface_Patch.h"
+#include "idlib/geometry/Surface_Polytope.h"
+#include "idlib/geometry/Surface_SweptSpline.h"
+#include "idlib/geometry/TraceModel.h"
+
+// text manipulation
+#include "idlib/Str.h"
+#include "idlib/Token.h"
+#include "idlib/Lexer.h"
+#include "idlib/Parser.h"
+// FIXME #include "idlib/Base64.h"
+#include "idlib/CmdArgs.h"
+
+// containers
+#include "idlib/containers/BTree.h"
+#include "idlib/containers/BinSearch.h"
+#include "idlib/containers/HashIndex.h"
+#include "idlib/containers/HashTable.h"
+#include "idlib/containers/StaticList.h"
+#include "idlib/containers/LinkList.h"
+#include "idlib/containers/Hierarchy.h"
+#include "idlib/containers/Queue.h"
+#include "idlib/containers/Stack.h"
+#include "idlib/containers/StrList.h"
+#include "idlib/containers/StrPool.h"
+#include "idlib/containers/VectorSet.h"
+#include "idlib/containers/PlaneSet.h"
+
+// hashing
+// FIXME #include "idlib/hashing/CRC32.h"
+#include "idlib/hashing/MD4.h"
+#include "idlib/hashing/MD5.h"
+
+// misc
+#include "idlib/Dict.h"
+#include "idlib/LangDict.h"
+#include "idlib/BitMsg.h"
+#include "idlib/MapFile.h"
+#include "idlib/Timer.h"
+
+// framework
+// FIXME #include "framework/BuildVersion.h"
+#include "framework/Licensee.h"
+#include "framework/CmdSystem.h"
+#include "framework/CVarSystem.h"
+#include "framework/Common.h"
+#include "framework/File.h"
+#include "framework/FileSystem.h"
+#include "framework/UsercmdGen.h"
+
+// decls
+#include "framework/DeclManager.h"
+#include "framework/DeclTable.h"
+#include "framework/DeclSkin.h"
+#include "framework/DeclEntityDef.h"
+#include "framework/DeclFX.h"
+#include "framework/DeclParticle.h"
+#include "framework/DeclAF.h"
+//#include "framework/DeclPDA.h"
+
+// We have expression parsing and evaluation code in multiple places:
+// materials, sound shaders, and guis. We should unify them.
+
+// renderer
+// FIXME: #include "renderer/qgl.h"
+// FIXME: #include "renderer/Cinematic.h"
+// FIXME: #include "renderer/Material.h"
+// FIXME: #include "renderer/Model.h"
+// FIXME: #include "renderer/ModelManager.h"
+// FIXME: #include "renderer/RenderWorld.h"
+
+#include "renderer/RenderSystem.h"
+
+// sound engine
+#include "sound/sound.h"
+
+// asynchronous networking
+#include "framework/async/NetworkSystem.h"
+
+// user interfaces
+#include "ui/ListGUI.h"
+#include "ui/UserInterface.h"
+
+// collision detection system
+#include "cm/CollisionModel.h"
+
+// AAS files and manager
+#include "tools/compilers/aas/AASFile.h"
+#include "tools/compilers/aas/AASFileManager.h"
+
+
+//-----------------------------------------------------
+
+//#include "framework/DemoChecksum.h"
+
+// framework
+#include "framework/Compressor.h"
+#include "framework/EventLoop.h"
+#include "framework/KeyInput.h"
+#include "framework/EditField.h"
+#include "framework/Console.h"
+#include "framework/DemoFile.h"
+#include "framework/Session.h"
+
+// asynchronous networking
+#include "framework/async/AsyncNetwork.h"
+
+// Compilers for map, model, video etc. processing.
+#include "tools/compilers/compiler_public.h"
+
+#endif // DEBUGGER_COMMON_H

--- a/tools/edit_stub.cpp
+++ b/tools/edit_stub.cpp
@@ -54,12 +54,6 @@ bool	GUIEditorHandleMessage( void *msg ) { return false; }
 
 void	DebuggerClientLaunch( void ) {}
 void	DebuggerClientInit( const char *cmdline ) { common->Printf( "The Script Debugger Client only runs on Win32\n" ); }
-#if 0 // dhewm3 doesn't have the following (probably because debugger *server* is cross-platform)
-bool	DebuggerServerInit( void ) { return false; }
-void	DebuggerServerShutdown( void ) {}
-void	DebuggerServerPrint( const char *text ) {}
-void	DebuggerServerCheckBreakpoint( idInterpreter *interpreter, idProgram *program, int instructionPointer ) {}
-#endif
 
 void	MaterialEditorInit() { common->Printf( "The Material editor only runs on Win32\n" ); }
 void	MaterialEditorPrintConsole( const char *text ) {}

--- a/tools/edit_stub.cpp
+++ b/tools/edit_stub.cpp
@@ -54,10 +54,12 @@ bool	GUIEditorHandleMessage( void *msg ) { return false; }
 
 void	DebuggerClientLaunch( void ) {}
 void	DebuggerClientInit( const char *cmdline ) { common->Printf( "The Script Debugger Client only runs on Win32\n" ); }
+#if 0 // dhewm3 doesn't have the following (probably because debugger *server* is cross-platform)
 bool	DebuggerServerInit( void ) { return false; }
 void	DebuggerServerShutdown( void ) {}
 void	DebuggerServerPrint( const char *text ) {}
 void	DebuggerServerCheckBreakpoint( idInterpreter *interpreter, idProgram *program, int instructionPointer ) {}
+#endif
 
 void	MaterialEditorInit() { common->Printf( "The Material editor only runs on Win32\n" ); }
 void	MaterialEditorPrintConsole( const char *text ) {}


### PR DESCRIPTION
Doom3 GPL contained most of the source of the script debugger that used to be part of Quake4.
Harrie van Ginneken fixed it for dhewm3 by implementing the missing parts and we further improved it together.

![debugger](https://github.com/user-attachments/assets/8a195242-bf39-4026-ab9c-475074289b52)

Like all the original Tools it's mostly Windows-only, but it's actually split into client (that Windows MFC frontend) and server, and the serverpart should also work on Linux (tested that on dhewm3 a while back, didn't test it in TDM now). And I guess TDM also works fine in Wine?

On Windows, just enter `debugger` in the console to start it.

Then go to the "Scripts" Tab and select a script you're interested in and find an interesting function and set a breakpoint (click in the line and press F9 or click to the left of the line number where that dot will appear).
When the game gets to that point it will pause and you can inspect the function in the script debugger or step through it line-by-line with F10/F11 (or those buttons); you can make it continue running normally (until it hits a breakpoint again) by pressing that little triangular "play" button at the top.

When hovering variables with the mouse cursor, it should show their current value. Doesn't seem to work for constants though..

After clicking a variable you can press Shift+F9 to get into some "quick watch" view, where you can also add the variable to the watch tab

Also check out the context menu in the text view showing the script source (no you can't edit it there).

Generally it's kinda ugly and janky, but better than nothing.

## Download

Here's a testbuild for Windows, based on current trunk code, seems to work with latest 2.14 beta game data: [TheDarkModx64-scriptdbg2.zip](https://github.com/user-attachments/files/25221739/TheDarkModx64-scriptdbg2.zip)

Linux build: [thedarkmod.x64-script-dbg-linux.zip](https://github.com/user-attachments/files/25237380/thedarkmod.x64-script-dbg-linux.zip)


## More details

The script debugger will actually run in a separate process, same you get when starting thedarkmod with the `+debugger` commandline argument (then you get only the debugger window).

For the networked setup, the following CVars are relevant: `com_enableDebuggerServer`, `com_dbgClientAdr` and `com_dbgServerAdr`.

Maybe (on Linux) you could even run `TheDarkModx64.exe +debugger` in Wine and the native darkmod (on the same machine) with `+set com_enableDebuggerServer 1` and they may find each other. Likely you need to start the native one with the server first, if anyone tries please let me know :)